### PR TITLE
feat(sim): add endpointCycles for asymmetric CDC + fix Tutorial

### DIFF
--- a/Sparkle/Core/SimParallel.lean
+++ b/Sparkle/Core/SimParallel.lean
@@ -100,6 +100,12 @@ def runMultiDomainSim
     - `[prod, cons]` with one connection → `runMultiDomainSim` (CDC queue)
     - anything else → `IO.userError` describing the limitation.
 
+    `cycles` sets a uniform cycle budget that applies to every endpoint. To
+    model a CDC with genuinely different clock frequencies (e.g. a 200 MHz
+    producer talking to a 100 MHz consumer) pass `endpointCycles` instead:
+    it gives a per-endpoint cycle count and `cycles` is ignored when it is
+    non-empty. The list must have the same length as `endpoints`.
+
     Limitations:
     - 3+ endpoints are not yet supported (needs multi-queue runCDC).
     - Multi-connection between the same pair of endpoints is not yet
@@ -108,24 +114,35 @@ def runMultiDomainSim
 def runSim
     (endpoints : List SimEndpoint)
     (connections : List Connection := [])
-    (cycles : UInt64)
+    (cycles : UInt64 := 0)
+    (endpointCycles : List UInt64 := [])
     : IO SimStats := do
-  match endpoints, connections with
-  | [ep], [] => runSingleSim ep cycles
-  | [ep], _  :: _ =>
+  -- Resolve the per-endpoint cycle budget. If the caller supplied an
+  -- explicit list, it wins; otherwise fall back to the uniform `cycles`.
+  let cyclesPerEp : List UInt64 ←
+    if endpointCycles.isEmpty then
+      pure (endpoints.map (fun _ => cycles))
+    else if endpointCycles.length != endpoints.length then
+      throw (IO.userError
+        s!"runSim: endpointCycles length ({endpointCycles.length}) must match endpoints length ({endpoints.length}).")
+    else
+      pure endpointCycles
+  match endpoints, connections, cyclesPerEp with
+  | [ep], [], [n] => runSingleSim ep n
+  | [ep], _  :: _, _ =>
     throw (IO.userError
       s!"runSim: single endpoint '{ep.moduleName}' cannot have connections; use runSim [ep] (cycles := ...) instead.")
-  | [prod, cons], [c] =>
-    runMultiDomainSim prod cons c cycles cycles
-  | [prod, cons], [] =>
+  | [prod, cons], [c], [nA, nB] =>
+    runMultiDomainSim prod cons c nA nB
+  | [prod, cons], [], _ =>
     throw (IO.userError
       s!"runSim: two endpoints ('{prod.moduleName}', '{cons.moduleName}') require exactly one connection. \
          If you meant two independent runs, call runSingleSim on each endpoint.")
-  | [_, _], _ :: _ :: _ =>
+  | [_, _], _ :: _ :: _, _ =>
     throw (IO.userError
       s!"runSim: multi-connection CDC is not yet supported (got {connections.length} connections). \
          See KnownIssues Issue 3.1.")
-  | _, _ =>
+  | _, _, _ =>
     throw (IO.userError
       s!"runSim: only 1 or 2 endpoints are supported (got {endpoints.length}). \
          See KnownIssues Issue 3.2.")

--- a/Tests/CDC/MultiClockTest.lean
+++ b/Tests/CDC/MultiClockTest.lean
@@ -90,15 +90,17 @@ def main : IO UInt32 := do
 
   IO.println ""
   IO.println "--- CDC Multi-threaded Run via runSim (auto-select) ---"
-  IO.println "  runSim [A, B] connection=(count -> value), cycles=200000"
+  IO.println "  runSim [A, B] connection=(count -> value), endpointCycles=[200k, 100k]"
 
   -- Use the high-level runSim auto-selector. With 2 endpoints + 1 connection
   -- it automatically dispatches to the CDC parallel backend. Named port
   -- connections replace raw port-index constants for better ergonomics.
+  -- endpointCycles models a 2:1 frequency ratio (DomainA runs at 2x the
+  -- rate of DomainB), exercising the CDC queue's rollback path.
   let stats ← runSim
     [simA.toEndpoint, simB.toEndpoint]
     (connections := [("count", "value")])
-    (cycles := 200000)
+    (endpointCycles := [200000, 100000])
 
   IO.println s!"  Messages sent:     {stats.messagesSent}"
   IO.println s!"  Messages received: {stats.messagesReceived}"

--- a/Tests/Sim/SimRunnerTest.lean
+++ b/Tests/Sim/SimRunnerTest.lean
@@ -414,6 +414,46 @@ def main : IO UInt32 := do
     JIT.destroy a.handle; JIT.destroy aFresh.handle
 
   -- --------------------------------------------------------------------------
+  -- F1: endpointCycles asymmetric (200k / 100k) — producer runs twice as fast
+  -- --------------------------------------------------------------------------
+  do
+    let a ← loadA; a.reset; a.step { enable := 1 }
+    let b ← loadB; b.reset
+    let stats ← runSim
+      [a.toEndpoint, b.toEndpoint]
+      (connections := [("count", "value")])
+      (endpointCycles := [200000, 100000])
+    st ← check st "F1 endpointCycles asymmetric: messages > 0"
+      (stats.messagesSent > 0 && stats.messagesReceived > 0)
+    JIT.destroy a.handle; JIT.destroy b.handle
+
+  -- --------------------------------------------------------------------------
+  -- F2: endpointCycles length mismatch rejected
+  -- --------------------------------------------------------------------------
+  do
+    let a ← loadA; let b ← loadB; a.reset; b.reset
+    let err ← expectError (do
+      let _ ← runSim
+        [a.toEndpoint, b.toEndpoint]
+        (connections := [("count", "value")])
+        (endpointCycles := [1000])  -- 1 value for 2 endpoints
+      pure ())
+    st ← check st "F2 endpointCycles length mismatch rejected" err
+    JIT.destroy a.handle; JIT.destroy b.handle
+
+  -- --------------------------------------------------------------------------
+  -- F3: endpointCycles wins over cycles when both are given
+  -- --------------------------------------------------------------------------
+  do
+    let a ← loadA; a.reset; a.step { enable := 1 }
+    let stats ← runSim
+      [a.toEndpoint]
+      (cycles := 1)                    -- tiny, should be ignored
+      (endpointCycles := [5000])       -- this one wins
+    st ← check st "F3 endpointCycles overrides cycles" (stats.cyclesRun == 5000)
+    JIT.destroy a.handle
+
+  -- --------------------------------------------------------------------------
   -- Summary
   -- --------------------------------------------------------------------------
   IO.println ""

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -329,20 +329,55 @@ def main : IO Unit := do
 
 ### Multi-domain (CDC)
 
+A Clock Domain Crossing (CDC) sim runs each module on its own thread,
+each with its own clock. The two clocks are **not** physically modeled:
+Sparkle gives each endpoint its own Verilog `clk` port that `JIT.evalTick`
+drives independently, and the frequency ratio is expressed by how many
+cycles each thread executes. A lock-free SPSC queue ferries data across
+the boundary, with snapshot/rollback to recover from timestamp inversion.
+
+To model e.g. a 200 MHz producer feeding a 100 MHz consumer, pass
+`endpointCycles` with per-endpoint budgets whose ratio matches the
+frequency ratio:
+
 ```lean
-sim! "module producer (input clk, input rst, output [31:0] data_out); ... endmodule"
-sim! "module consumer (input clk, input rst, input [31:0] data_in); ... endmodule"
+import Sparkle.Core.SimParallel
+open Sparkle.Core.SimParallel
+
+-- Each module gets its own `clk`. They are independent clock domains at
+-- runtime: Sparkle runs each on its own thread, ticking at its own rate.
+sim! "module producer_mod (input clk, input rst, output [31:0] data_out); ... endmodule"
+sim! "module consumer_mod (input clk, input rst, input  [31:0] data_in); ... endmodule"
 
 def main : IO Unit := do
-  let p ← producer.Sim.load
-  let c ← consumer.Sim.load
+  let p ← producer_mod.Sim.load
+  let c ← consumer_mod.Sim.load
   p.reset; c.reset
+  -- Producer runs at 200 MHz, consumer at 100 MHz → 2:1 cycle ratio.
   let stats ← runSim
     [p.toEndpoint, c.toEndpoint]
     (connections := [("data_out", "data_in")])
-    (cycles := 1_000_000)
-  IO.println s!"sent={stats.messagesSent} recv={stats.messagesReceived}"
+    (endpointCycles := [200_000, 100_000])
+  IO.println s!"sent={stats.messagesSent} recv={stats.messagesReceived} rb={stats.rollbacks}"
 ```
+
+If both domains run at the same frequency, use the simpler uniform
+`cycles` parameter instead:
+
+```lean
+let stats ← runSim
+  [p.toEndpoint, c.toEndpoint]
+  (connections := [("data_out", "data_in")])
+  (cycles := 1_000_000)
+```
+
+**Important**: merely writing `input clk` in two `sim!` modules does
+NOT by itself create two domains — at the Verilog level each module
+just has a clock port. The "two-domain-ness" comes from `runSim`
+running each endpoint on its own thread with its own cycle count,
+plus the SPSC queue that CDC-synchronizes the payload. If you need
+hard guarantees (e.g. a full 2-flop synchronizer inside the consumer),
+add the synchronizer registers to the consumer's Verilog explicitly.
 
 Connections are specified as `(producerOutputName, consumerInputName)`
 string pairs. `runSim` looks up the port indices at runtime via the
@@ -374,8 +409,9 @@ and can be improved.
   (Issue 3.2).
 
 See `Examples/CDC/MultiClockSim.lean` for a working end-to-end example
-and `Tests/Sim/SimRunnerTest.lean` for the 27-test regression suite
-(equivalence, auto-select, port-name errors, index alignment, stress).
+and `Tests/Sim/SimRunnerTest.lean` for the 30-test regression suite
+(equivalence, auto-select, port-name errors, index alignment, stress,
+and asymmetric endpointCycles).
 
 ---
 
@@ -404,8 +440,8 @@ and `Tests/Sim/SimRunnerTest.lean` for the 27-test regression suite
       │                    │
       ├── VCD waveform     ├── JIT C++ → .so → fast simulation
       │                    │                      │
-      └── Formal proofs    ├── OracleReduction     ├── runSim (auto)
-          (bv_decide)      │   (proof-driven opt)  │   ├─ runSingleSim
+      └── Formal proofs    ├── OracleReductin     ├── runSim (auto)
+          (bv_decide)      │   (proof-driven opt) │   ├─ runSingleSim
                            │                      │   └─ runMultiDomainSim
                            │                      │      (CDC queue)
                            └──────────────────────┘


### PR DESCRIPTION
The CDC example in Tutorial.md Step 6 was misleading: both 'producer' and 'consumer' modules wrote 'input clk' and the call site passed a single uniform 'cycles := 1_000_000', making it look like the two endpoints shared a clock. They don't — runSim runs each endpoint on its own thread with its own independent evalTick loop — but the example provided no way to express a frequency ratio either.

Worse, the runSim refactor that introduced the typed API had silently regressed the original JIT.runCDC functionality: runCDC accepted two distinct cycle budgets (cyclesA, cyclesB) which let callers model e.g. a 2:1 clock ratio, but my runSim wrapper passed the same 'cycles' value to both sides, flattening every CDC sim to a 1:1 ratio. Tests/CDC/ MultiClockTest had quietly inherited this by switching from 200k/100k to 200k/200k when I ported it.

Changes:

- Sparkle/Core/SimParallel.lean: runSim gains an optional 'endpointCycles : List UInt64 := []' parameter. When non-empty it must have the same length as endpoints, and each entry becomes that endpoint's cycle budget (overriding the uniform 'cycles'). When empty the old behaviour is preserved. runSingleSim and runMultiDomainSim are unchanged.

- Tests/CDC/MultiClockTest.lean: restore the historical 200k / 100k asymmetry with endpointCycles := [200000, 100000]. The CDC queue now genuinely exercises the 2:1 ratio again (81k sent, 80k received vs the symmetric 100k/100k).

- Tests/Sim/SimRunnerTest.lean: three new regression tests (now 30/30): F1 asymmetric endpointCycles [200k,100k] delivers messages F2 length mismatch between endpoints and endpointCycles is rejected F3 endpointCycles overrides 'cycles' when both are given

- docs/Tutorial.md: rewrote the CDC section. Renamed the example modules to producer_mod / consumer_mod, introduced endpointCycles with an explicit 200 MHz / 100 MHz cycle ratio, and added a plain- language warning that writing 'input clk' in two sim! modules does NOT by itself create two domains — the two-domain-ness comes from runSim running each endpoint on its own thread plus the SPSC queue that CDC-synchronizes the payload. Users who need a hard 2-flop synchronizer still have to add it in their Verilog explicitly.

Verified:
  lake exe svparser-test           34/34
  lake exe sim-runner-test         30/30  (+3 from F1-F3)
  lake exe cdc-multi-clock-test    PASS   (now exercising 200k/100k)