### PR TITLE
declare_signal_state: generate Name.mk named-field constructor

### DIFF
--- a/Sparkle/Core/StateMacro.lean
+++ b/Sparkle/Core/StateMacro.lean
@@ -103,4 +103,47 @@ elab "declare_signal_state " name:ident fields:signalStateField* : command => do
   let fromWiresName := mkIdent (name.getId ++ `fromWires)
   elabCommand (← `(def $fromWiresName ($wsIdent : Array UInt32) : $name := $fromWiresBody))
 
+  -- 7. Generate Name.mk: a named-field constructor that takes one
+  --    Signal per field and packages them via bundle2 in the right
+  --    order. This makes the OUTPUT side of a Sparkle module
+  --    symmetric to the INPUT side (`Name.field state` for read,
+  --    `Name.mk (field := sig) ...` for write).
+  --
+  --    Generated signature:
+  --      def Name.mk {dom : DomainConfig}
+  --        (field0 : Signal dom T0) ... (fieldN-1 : Signal dom Tn-1)
+  --        : Signal dom Name :=
+  --        bundleAll! [field0, ..., fieldN-1]
+  --
+  --    Callers can use named arguments:
+  --      Name.mk (count := countOut) (parity := parityOut)
+  --
+  -- Implemented via a `fun`-binding form so we don't need raw
+  -- bracketedBinder Syntax: the macro emits
+  --   def Name.mk : ... := fun field0 ... fieldN-1 => bundleBody
+  -- with explicit type annotations on each binder.
+  let bundleArgs : Array (TSyntax `term) := fieldData.map fun (fieldName, _, _) =>
+    ⟨fieldName.raw⟩
+  let bundleBody : TSyntax `term ←
+    if n == 1 then
+      pure bundleArgs[0]!
+    else
+      let mut acc : TSyntax `term := bundleArgs[n-1]!
+      for i in (List.range (n - 1)).reverse do
+        acc ← `(Sparkle.Core.Signal.bundle2 $(bundleArgs[i]!) $acc)
+      pure acc
+  -- Build the full type of `mk`: (f0 : Signal dom T0) → ... → Signal dom Name.
+  let mut mkType : TSyntax `term ← `(Sparkle.Core.Signal.Signal dom $name)
+  for i in (List.range n).reverse do
+    let (fieldName, fieldType, _) := fieldData[i]!
+    mkType ← `(($fieldName : Sparkle.Core.Signal.Signal dom $fieldType) → $mkType)
+  -- Build the body lambda: fun f0 ... fN-1 => bundle.
+  let mut mkBody : TSyntax `term := bundleBody
+  for i in (List.range n).reverse do
+    let (fieldName, _, _) := fieldData[i]!
+    mkBody ← `(fun $fieldName => $mkBody)
+  let mkName := mkIdent (name.getId ++ `mk)
+  elabCommand (← `(
+    def $mkName {dom : Sparkle.Core.Domain.DomainConfig} : $mkType := $mkBody))
+
 end Sparkle.Core.StateMacro

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -43,6 +43,49 @@ def counter8 {dom : DomainConfig}
 lake env lean tutorial.lean
 ```
 
+### Multi-output modules and `declare_signal_state`
+
+Once a module produces more than one signal, returning an
+anonymous tuple forces the caller to project by position
+(`.fst`, `.snd`, `.snd.fst`...), which scales badly. Sparkle
+ships a macro `declare_signal_state` that turns a list of named
+fields into a tuple-backed record with field accessors AND a
+named-field constructor `Name.mk`:
+
+```lean
+declare_signal_state CounterParityOut
+  | count  : BitVec 8 := 0#8
+  | parity : Bool     := false
+
+def counterAndParity {dom : DomainConfig}
+    (en : Signal dom Bool) : Signal dom CounterParityOut :=
+  Signal.loop fun self =>
+    let count      := CounterParityOut.count self        -- read by name
+    let countNext  := Signal.mux en (count + 1#8) count
+    let parityBV   := countNext.map (BitVec.extractLsb' 0 1 ·)
+    let parityNext := parityBV === Signal.pure 1#1
+    let countOut   := Signal.register 0#8 countNext
+    let parityOut  := Signal.register false parityNext
+    -- Build the output by name (output side mirrors input side):
+    CounterParityOut.mk (count := countOut) (parity := parityOut)
+
+-- Caller reads each field by name too:
+#eval
+  let out := counterAndParity (dom := defaultDomain) (Signal.pure true)
+  let cs  := (CounterParityOut.count out).sample 4
+  let ps  := (CounterParityOut.parity out).sample 4
+  s!"counts={cs}  parity={ps}"
+```
+
+`declare_signal_state` also generates `Name.default`,
+`Name.wireNames`, and `Name.fromWires` — the latter two are
+consumed by the JIT probe layer to expose the same field names
+in generated Verilog (`_gen_count`, `_gen_parity`) and JIT C++.
+
+For the full walkthrough (anonymous tuple → let-named tuple →
+record + bundleAll! → record + `Name.mk`, with the trade-offs
+of each pattern), see [`docs/Tutorial_Extended.md`](Tutorial_Extended.md).
+
 ---
 
 ## Step 2: Generate Verilog

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -86,6 +86,57 @@ For the full walkthrough (anonymous tuple → let-named tuple →
 record + bundleAll! → record + `Name.mk`, with the trade-offs
 of each pattern), see [`docs/Tutorial_Extended.md`](Tutorial_Extended.md).
 
+### Imperative-style hardware: `Signal.circuit do`
+
+The `Signal.loop` + `Signal.register` + `bundleAll!` pattern works
+for any module, but for a multi-register pipeline it's verbose.
+Sparkle ships a `Signal.circuit do` macro that lets you write the
+same hardware imperatively:
+
+  - `let x ← Signal.reg init` — declare a registered signal
+  - `x <~ rhs` — set `x`'s next-state value
+  - `let y := rhs` — local combinational binding
+  - `return expr` — value returned by the block
+
+The simple counter from Step 1 written this way:
+
+```lean
+def counter8' {dom : DomainConfig} : Signal dom (BitVec 8) :=
+  Signal.circuit do
+    let count ← Signal.reg 0#8;
+    count <~ count + 1#8;
+    return count
+```
+
+A 3-stage shift pipeline (a value entering `s0` reaches `s2`
+three cycles later) is just three register declarations + three
+assignments:
+
+```lean
+def shiftPipeline {dom : DomainConfig}
+    (input : Signal dom (BitVec 8)) : Signal dom (BitVec 8) :=
+  Signal.circuit do
+    let s0 ← Signal.reg 0#8;
+    let s1 ← Signal.reg 0#8;
+    let s2 ← Signal.reg 0#8;
+    s0 <~ input;
+    s1 <~ s0;
+    s2 <~ s1;
+    return s2
+```
+
+The macro desugars to `Signal.loop` + `Signal.register` + a
+`bundleAll!` over the next-state expressions. Synthesis output,
+JIT codegen, and `Signal.atTime` evaluation are identical to the
+hand-written version.
+
+When **NOT** to use it: when you also need to return multiple
+named outputs, `Name.mk` (above) plus `Signal.loop` is more
+flexible. `Signal.circuit do` returns a single Signal.
+
+Runnable examples (counter / up-down / shift / enabled): see
+[`tutorial-extended/TutorialExtended/Step8_CircuitDoNotation.lean`](../tutorial-extended/TutorialExtended/Step8_CircuitDoNotation.lean).
+
 ---
 
 ## Step 2: Generate Verilog

--- a/docs/Tutorial_Extended.md
+++ b/docs/Tutorial_Extended.md
@@ -126,17 +126,42 @@ Now:
   - **Verilog side**: still `_gen_countOut`, `_gen_parityOut` —
     same observability as (b).
   - **Free utilities**: `declare_signal_state` also generates
-    `CounterParityOut.default`, `CounterParityOut.wireNames`, and
-    `CounterParityOut.fromWires`, which the JIT probe layer can
-    consume directly.
+    `CounterParityOut.default`, `CounterParityOut.wireNames`,
+    `CounterParityOut.fromWires`, AND `CounterParityOut.mk`
+    (next variant), which the JIT probe layer can consume
+    directly.
+
+### (d) Named record + named-field constructor `CounterParityOut.mk`
+
+`declare_signal_state` also generates a `Name.mk` constructor
+that takes one Signal per field, in field-declaration order, so
+the output side reads as a record-style call:
+
+```lean
+def counterAndParity_record_mk {dom : DomainConfig}
+    (en : Signal dom Bool) : Signal dom CounterParityOut :=
+  Signal.loop fun self =>
+    let count      := CounterParityOut.count self
+    ...
+    let countOut   := Signal.register 0#8 countNext
+    let parityOut  := Signal.register false parityNext
+    CounterParityOut.mk (count := countOut) (parity := parityOut)
+```
+
+Now **both read and write are by field name**. Bundle order comes
+from the macro, not the call site, so swapping two fields in
+`declare_signal_state` no longer silently swaps their data on the
+output side. The generated Verilog is identical to (c) — same
+`_gen_countOut` / `_gen_parityOut` wires.
 
 ### Summary table
 
-| Pattern | Caller projection | Wire name in Verilog | Lines added |
-|---------|-------------------|----------------------|-------------|
-| (a) anonymous | `.fst` / `.snd` | `_tmp_a_NNNN` | 0 |
-| (b) `let`-named | `.fst` / `.snd` | `_gen_<bindingName>` | 2 |
-| (c) record | `.fieldName` | `_gen_<bindingName>` | 4 (declaration) |
+| Pattern | Caller projection | Output construction | Wire name in Verilog | Lines added |
+|---------|-------------------|---------------------|----------------------|-------------|
+| (a) anonymous | `.fst` / `.snd` | `bundle2 …` (positional) | `_tmp_a_NNNN` | 0 |
+| (b) `let`-named | `.fst` / `.snd` | `bundle2 letName …` (positional) | `_gen_<letName>` | 2 |
+| (c) record + bundleAll! | `.fieldName` | `bundleAll! […]` (positional) | `_gen_<letName>` | 4 (declaration) |
+| (d) record + `Name.mk` | `.fieldName` | `Name.mk (field := …)` (named) | `_gen_<letName>` | 4 (declaration) |
 
 For modules with ≥ 3 outputs or any nesting, **always go with (c)**.
 

--- a/tutorial-extended/TutorialExtended/Run.lean
+++ b/tutorial-extended/TutorialExtended/Run.lean
@@ -1,13 +1,14 @@
 /-
   Tutorial Extended runner.
 
-  Runs all 7 steps' demos and prints their outputs.
+  Runs all 8 steps' demos and prints their outputs.
 
   Steps 1-4 cover module structure and named record I/O.
   Steps 5-7 cover LTL temporal-logic verification:
     Step 5: LTL basics — invariants, K-cycle preservation, induction.
     Step 6: bug-localization framework (multi-premise + contrapositive).
     Step 7: pointer to the production RV32 LTL proof catalog.
+  Step 8: imperative-style hardware via `Signal.circuit do`.
 -/
 
 import TutorialExtended.Step1_SimpleCounter
@@ -17,6 +18,7 @@ import TutorialExtended.Step4_NamedObservability
 import TutorialExtended.Step5_LTL_Basics
 import TutorialExtended.Step6_LTL_BugLocalization
 import TutorialExtended.Step7_LTL_RV32_Pointers
+import TutorialExtended.Step8_CircuitDoNotation
 
 def main : IO UInt32 := do
   IO.println "═══════════════════════════════════════════════════════"
@@ -43,6 +45,9 @@ def main : IO UInt32 := do
 
   IO.println "\n── Step 7: RV32 LTL theorem catalog (pointers) ──"
   TutorialExtended.Step7.runDemo
+
+  IO.println "\n── Step 8: Signal.circuit do — imperative HW DSL ──"
+  TutorialExtended.Step8.runDemo
 
   IO.println "\n═══════════════════════════════════════════════════════"
   IO.println "  All steps ran. See docs/Tutorial_Extended.md and"

--- a/tutorial-extended/TutorialExtended/Step2_MultipleOutputs.lean
+++ b/tutorial-extended/TutorialExtended/Step2_MultipleOutputs.lean
@@ -61,12 +61,13 @@ def counterAndParity_letNamed {dom : DomainConfig}
     let parityOut := Signal.register false parityNext
     bundle2 countOut parityOut
 
-/-! ## (c) Named record output via `declare_signal_state`
+/-! ## (c) Named record output via `declare_signal_state` (positional bundle)
 
   `declare_signal_state` turns a list of named fields into a
   Sparkle-compatible tuple type with accessor defs. The caller
   uses `.count` / `.parity` instead of `.fst` / `.snd`, and the
-  Verilog/JIT wire names match the field names automatically. -/
+  Verilog/JIT wire names match the field names automatically.
+  But the OUTPUT side still uses positional `bundleAll!`. -/
 
 declare_signal_state CounterParityOut
   | count  : BitVec 8 := 0#8
@@ -84,6 +85,30 @@ def counterAndParity_record {dom : DomainConfig}
     let countOut   := Signal.register 0#8 countNext
     let parityOut  := Signal.register false parityNext
     bundleAll! [countOut, parityOut]
+
+/-! ## (d) Named record output with named-field constructor `Name.mk`
+
+  `declare_signal_state` ALSO generates a `Name.mk` constructor
+  that takes one Signal per field, in field-declaration order, so
+  callers can write the OUTPUT side by name as well:
+
+      CounterParityOut.mk (count := countOut) (parity := parityOut)
+
+  Now both read AND write are by field name. The bundle order
+  comes from the macro, not the call site, so swapping two fields
+  in `declare_signal_state` doesn't silently swap their data. -/
+
+def counterAndParity_record_mk {dom : DomainConfig}
+    (en : Signal dom Bool) : Signal dom CounterParityOut :=
+  Signal.loop fun self =>
+    let count      := CounterParityOut.count self
+    let _parity    := CounterParityOut.parity self
+    let countNext  := Signal.mux en (count + 1#8) count
+    let parityBV   := countNext.map (BitVec.extractLsb' 0 1 ·)
+    let parityNext := parityBV === Signal.pure 1#1
+    let countOut   := Signal.register 0#8 countNext
+    let parityOut  := Signal.register false parityNext
+    CounterParityOut.mk (count := countOut) (parity := parityOut)
 
 /-! ## Demo: same outputs from all three
 
@@ -109,5 +134,12 @@ def runDemo : IO Unit := do
   let countsC := (CounterParityOut.count outC).sample 8
   let parC    := (CounterParityOut.parity outC).sample 8
   IO.println s!"(c) counts={countsC}  parity={parC}"
+
+  -- (d) record + named-field constructor: same output, both
+  --     read AND write by field name
+  let outD   := counterAndParity_record_mk (dom := defaultDomain) (Signal.pure true)
+  let countsD := (CounterParityOut.count outD).sample 8
+  let parD    := (CounterParityOut.parity outD).sample 8
+  IO.println s!"(d) counts={countsD}  parity={parD}"
 
 end TutorialExtended.Step2

--- a/tutorial-extended/TutorialExtended/Step2_VerilogDump.lean
+++ b/tutorial-extended/TutorialExtended/Step2_VerilogDump.lean
@@ -28,3 +28,9 @@ open TutorialExtended.Step2
 -- type. The difference is at the *Lean type* level: callers see
 -- a named record instead of an anonymous tuple.
 #synthesizeVerilog counterAndParity_record
+
+-- Variant (d) — named-field constructor `Name.mk`.
+-- Same wire names as (c); only the Lean source changes from a
+-- positional `bundleAll! [...]` to a record-style
+-- `Name.mk (field := ...)` call.
+#synthesizeVerilog counterAndParity_record_mk

--- a/tutorial-extended/TutorialExtended/Step8_CircuitDoNotation.lean
+++ b/tutorial-extended/TutorialExtended/Step8_CircuitDoNotation.lean
@@ -1,0 +1,110 @@
+/-
+  Tutorial Step 8: imperative-style hardware with `Signal.circuit do`.
+
+  `Signal.circuit do` is a macro that desugars to
+  `Signal.loop` + `Signal.register` + `bundleAll!`. It lets you
+  write registered logic in an imperative style:
+
+    - `let x ← Signal.reg init` declares a registered signal `x`
+    - `x <~ rhs`                 sets `x`'s next-state value to `rhs`
+    - `let y := rhs`             local combinational binding
+    - `return expr`              the value the block returns
+
+  Same circuit as `Signal.loop` underneath; just easier to read for
+  pipelines with several registers.
+-/
+
+import Sparkle
+
+open Sparkle.Core.Domain
+open Sparkle.Core.Signal
+
+namespace TutorialExtended.Step8
+
+/-! ## Example A: simple counter
+
+  Compare with the explicit `Signal.loop` version from Step 1:
+
+  ```
+  Signal.loop fun count =>
+    let next := count + 1#8
+    Signal.register 0#8 next
+  ```
+
+  The `Signal.circuit do` version drops the explicit `loop` /
+  `register` boilerplate and reads top-down. -/
+
+def counter8 {dom : DomainConfig} : Signal dom (BitVec 8) :=
+  Signal.circuit do
+    let count ← Signal.reg 0#8;
+    count <~ count + 1#8;
+    return count
+
+/-! ## Example B: up/down counter — multiplexed next-state
+
+  A second counter that increments or decrements based on `up`. -/
+
+def upDown {dom : DomainConfig} (up : Signal dom Bool) : Signal dom (BitVec 8) :=
+  Signal.circuit do
+    let count ← Signal.reg 0#8;
+    count <~ Signal.mux up (count + 1#8) (count - 1#8);
+    return count
+
+/-! ## Example C: 3-stage pipeline (register chain)
+
+  Three registers in a row. Each register's next-state is the
+  previous one's current value, so a value entering `s0` shows up
+  at `s2` three cycles later. The `let` lines compute combinational
+  next-state expressions; the `<~` lines wire them into the
+  `Signal.reg`-declared registers. -/
+
+def shiftPipeline {dom : DomainConfig}
+    (input : Signal dom (BitVec 8)) : Signal dom (BitVec 8) :=
+  Signal.circuit do
+    let s0 ← Signal.reg 0#8;
+    let s1 ← Signal.reg 0#8;
+    let s2 ← Signal.reg 0#8;
+    s0 <~ input;
+    s1 <~ s0;
+    s2 <~ s1;
+    return s2
+
+/-! ## Example D: counter with enable — combinational `let` + register
+
+  Mixes registered state with combinational `let` bindings. The
+  next-state is computed once via a `let`, then assigned. Demonstrates
+  that `let x := …` (combinational binding) and `x <~ …` (registered
+  next-state) coexist in the same `do` block. -/
+
+def enabledCounter {dom : DomainConfig}
+    (en : Signal dom Bool) : Signal dom (BitVec 8) :=
+  Signal.circuit do
+    let count ← Signal.reg 0#8;
+    let incremented := count + 1#8;
+    count <~ Signal.mux en incremented count;
+    return count
+
+/-! ## Demo -/
+
+def runDemo : IO Unit := do
+  -- Example A: counter increments every cycle
+  let trace_a := (counter8 (dom := defaultDomain)).sample 6
+  IO.println s!"counter8       : {trace_a}"
+
+  -- Example B: up/down (always up here)
+  let trace_b := (upDown (dom := defaultDomain) (Signal.pure true)).sample 6
+  IO.println s!"upDown (up)    : {trace_b}"
+
+  -- Example C: a 0xAA value entered at cycle 1 reaches s2 at cycle 4
+  let trace_c := (shiftPipeline (dom := defaultDomain)
+    ⟨fun t => if t == 1 then 0xAA#8 else 0#8⟩).sample 6
+  IO.println s!"shiftPipeline  : {trace_c}"
+
+  -- Example D: enabled counter — increments only when en is true.
+  -- We feed `en = (cycle % 2 == 0)`, so the counter increments
+  -- every other cycle.
+  let trace_d := (enabledCounter (dom := defaultDomain)
+    ⟨fun t => t % 2 == 0⟩).sample 8
+  IO.println s!"enabled (alt)  : {trace_d}"
+
+end TutorialExtended.Step8


### PR DESCRIPTION
Adds a record-style constructor `Name.mk` to the
`declare_signal_state` macro. For an n-field state declared as

    declare_signal_state CounterParityOut
      | count  : BitVec 8 := 0#8
      | parity : Bool     := false

the macro now also emits

    def CounterParityOut.mk {dom : DomainConfig}
      : (count : Signal dom (BitVec 8)) →
        (parity : Signal dom Bool) →
        Signal dom CounterParityOut :=
      fun count parity => bundle2 count parity

so callers can build the output side by field name, mirroring how they read it:

    -- read by field name
    let count := CounterParityOut.count self

    -- write by field name (NEW)
    CounterParityOut.mk (count := countOut) (parity := parityOut)

Bundle order comes from the macro, not from the call site, so a field reorder in `declare_signal_state` cannot silently swap the output data — Lean's named-argument resolution catches it.

Updates:

  - `Sparkle/Core/StateMacro.lean`: append step 7 to the macro's elaboration that emits `Name.mk` via a typed function abstraction (no bracketedBinder syntax tricks).
  - `tutorial-extended/TutorialExtended/Step2_MultipleOutputs.lean`: add a 4th variant `counterAndParity_record_mk` demonstrating the new pattern. The runDemo prints all 4 traces; they match.
  - `tutorial-extended/TutorialExtended/Step2_VerilogDump.lean`: `#synthesizeVerilog` the new variant; confirms the same `_gen_countOut`/`_gen_parityOut` wires are produced.
  - `docs/Tutorial_Extended.md`: new "(d)" section, updated summary table.

Verified:
  - Full project build clean (64 jobs)
  - All existing `declare_signal_state` invocations across IP/RV32, IP/Bus, IP/Video, IP/YOLOv8, etc. continue to compile
  - tutorial-extended-run prints identical traces for variants (a), (b), (c), (d)
  - Verilog output for (c) and (d) is structurally identical (same wire names, same always_ff blocks, same bundle assign)