### PR TITLE
SVParser: reproduce + fix issues #41/#42/#43/#44/#45

### DIFF
--- a/Tests/SVParser/ParserTest.lean
+++ b/Tests/SVParser/ParserTest.lean
@@ -1470,8 +1470,12 @@ endmodule
   -- ===================================================================
 
   -- Test 30 (issue #41): reduction-AND `&x` on a sub-32-bit operand.
-  -- Bug: lowerExpr uses a hardcoded 32-bit all-ones mask, so
-  -- `&a` for `a = 4'b1111` returns 0 instead of 1.
+  -- Original bug: lowerExpr used a hardcoded 32-bit all-ones mask,
+  -- so `&a` for `a = 4'b1111` returned 0 instead of 1.
+  -- Now fixed indirectly by the `narrowMaskConstants` post-pass in
+  -- `Lower.lean` (the same pass that fixes Test 37).  Kept as a
+  -- regression guard so any future change that re-widens the mask
+  -- will fail here.
   IO.print "  Test 30: reduction-AND on 4-bit operand (issue #41)... "
   try
     let v := "
@@ -1685,9 +1689,10 @@ endmodule
   catch e => IO.println s!"FAIL: {e}"; failed := failed + 1
 
   -- Test 37: bitwise-NOT `~a` on a 4-bit operand, observed via a
-  -- downstream `+`.  Lower.lean line 161 XORs the operand with a
-  -- 32-bit `-1` constant, so `~a` may carry the upper-28 bits
-  -- (set to 1 by the 32-bit XOR) into adjacent arithmetic.
+  -- downstream `+`.  Lower.lean line 161 emits `x XOR -1` with a
+  -- 32-bit constant; without the `narrowMaskConstants` post-pass
+  -- the upper-28 XORed bits leak into adjacent arithmetic and
+  -- `~0 + 1` returns 0 instead of 16.  Fixed by that pass.
   IO.print "  Test 37: bitwise-NOT 4-bit, value-only check (Lower.lean:161)... "
   try
     let v := "

--- a/Tests/SVParser/ParserTest.lean
+++ b/Tests/SVParser/ParserTest.lean
@@ -1495,8 +1495,13 @@ endmodule
   catch e => IO.println s!"FAIL: {e}"; failed := failed + 1
 
   -- Test 31 (issue #42): two module instances chained via an internal wire.
-  -- Bug: flattenDesign drops the bridge wire, so `y = ~~a` collapses
-  -- to `y = ~a` (only the first instance survives).
+  -- Original-bug description: "flattenDesign drops the bridge wire,
+  -- so `y = ~~a` collapses to `y = ~a`."  The real root cause is
+  -- subtler — `lowerDesign` used to pick the *first* module in source
+  -- order as the top, so declaring sub-modules before the top (which
+  -- is the natural Verilog order — top last) caused the flattener to
+  -- treat the leaf sub-module as the top.  Fixed by `lowerDesign`
+  -- now picking the module that is not instantiated by any other.
   IO.print "  Test 31: chained module instances via internal wire (issue #42)... "
   try
     let v := "

--- a/Tests/SVParser/ParserTest.lean
+++ b/Tests/SVParser/ParserTest.lean
@@ -1456,5 +1456,150 @@ endmodule
       IO.println s!"FAIL: expected [28], got {results}"; failed := failed + 1
   catch e => IO.println s!"FAIL: {e}"; failed := failed + 1
 
+  -- ===================================================================
+  -- Tests 30-34: regression coverage for open SVParser bugs.
+  -- These reproduce the failures reported in issues #41-#45.  Each is
+  -- expected to FAIL on the affected commit and PASS once the
+  -- corresponding lowering / parser fix lands.
+  -- ===================================================================
+
+  -- Test 30 (issue #41): reduction-AND `&x` on a sub-32-bit operand.
+  -- Bug: lowerExpr uses a hardcoded 32-bit all-ones mask, so
+  -- `&a` for `a = 4'b1111` returns 0 instead of 1.
+  IO.print "  Test 30: reduction-AND on 4-bit operand (issue #41)... "
+  try
+    let v := "
+module bug1_reduction_and (input clk, input [3:0] a, output y);
+  assign y = &a;
+endmodule
+"
+    let results ← jitRun v
+      (fun h => do JIT.setInput h 0 0xF)  -- a = 4'b1111
+      1
+      (fun h => do let v ← JIT.getOutput h 0; return [v])
+    if results == [1] then
+      IO.println "PASS"; passed := passed + 1
+    else
+      IO.println s!"FAIL: expected [1] for &4'b1111, got {results} (issue #41)"
+      failed := failed + 1
+  catch e => IO.println s!"FAIL: {e}"; failed := failed + 1
+
+  -- Test 31 (issue #42): two module instances chained via an internal wire.
+  -- Bug: flattenDesign drops the bridge wire, so `y = ~~a` collapses
+  -- to `y = ~a` (only the first instance survives).
+  IO.print "  Test 31: chained module instances via internal wire (issue #42)... "
+  try
+    let v := "
+module inc (input [7:0] x, output [7:0] o);
+  assign o = ~x;
+endmodule
+
+module bug2_chained_inst (input clk, input [7:0] a, output [7:0] y);
+  wire [7:0] mid;
+  inc u1 (.x(a),   .o(mid));
+  inc u2 (.x(mid), .o(y));
+endmodule
+"
+    -- a = 125 → mid = ~125 = 130 → y = ~130 = 125 (= a)
+    let results ← jitRun v
+      (fun h => do JIT.setInput h 0 125)
+      1
+      (fun h => do let v ← JIT.getOutput h 0; return [v])
+    if results == [125] then
+      IO.println "PASS"; passed := passed + 1
+    else
+      IO.println s!"FAIL: expected [125], got {results} (issue #42 — likely 130 = ~125, second instance bypassed)"
+      failed := failed + 1
+  catch e => IO.println s!"FAIL: {e}"; failed := failed + 1
+
+  -- Test 32 (issue #43): signed comparison.
+  -- Bug: parser drops `signed`, Lower.lean hardcodes `.lt_u` for <,
+  -- so a signed-negative `a` is compared as a large unsigned value
+  -- and `(-106) < 127` returns 0 instead of 1.
+  IO.print "  Test 32: signed comparison `a < b` (issue #43)... "
+  try
+    let v := "
+module bug3_signed_lt (input clk, input signed [7:0] a, input signed [7:0] b, output lt);
+  assign lt = a < b;
+endmodule
+"
+    -- a = -106 (8'hFFFF...96 -> low 8 bits 0x96), b = 127 (0x7F)
+    let results ← jitRun v
+      (fun h => do JIT.setInput h 0 0x96  -- -106 as 8-bit two's complement
+                   JIT.setInput h 1 0x7F) -- 127
+      1
+      (fun h => do let v ← JIT.getOutput h 0; return [v])
+    if results == [1] then
+      IO.println "PASS"; passed := passed + 1
+    else
+      IO.println s!"FAIL: expected [1] for (-106) < 127 signed, got {results} (issue #43)"
+      failed := failed + 1
+  catch e => IO.println s!"FAIL: {e}"; failed := failed + 1
+
+  -- Test 33 (issue #44): parameter default width hardcoded to 32.
+  -- Bug: in Lower.lean `paramWidth` falls back to 32 for any
+  -- parameter without an explicit range, so an 8-bit-input port
+  -- declared `[W-1:0]` with default `parameter W = 8` resolves to
+  -- 32 bits instead of 8.  We exercise the symptom indirectly: the
+  -- module multiplies `a` (declared `[W-1:0]` with default W = 8)
+  -- by a literal — when the port is correctly 8-bit, `a` gets
+  -- masked to 0xFF before being multiplied; when the bug widens
+  -- the port to 32-bit, the upper 24 bits of whatever the host
+  -- passed in (or undefined garbage) participate in the product.
+  -- We feed a value with set bits above bit 7 (0x1FF = 511) and
+  -- multiply by 1 — a correctly-truncated module returns
+  -- 0x1FF & 0xFF = 0xFF = 255, but with the 32-bit-wide port the
+  -- full 0x1FF passes through.
+  IO.print "  Test 33: parameter default width truncates input (issue #44)... "
+  try
+    let v := "
+module bug4_param_default_width #(parameter W = 8) (input clk, input [W-1:0] a, output [15:0] y);
+  assign y = a;
+endmodule
+"
+    -- We feed 0x1FF.  If the port were correctly 8-bit it should
+    -- mask to 0xFF = 255; if W resolved to 32 (the bug), the input
+    -- propagates as 0x1FF = 511.
+    let results ← jitRun v
+      (fun h => do JIT.setInput h 0 0x1FF)
+      1
+      (fun h => do let v ← JIT.getOutput h 0; return [v])
+    if results == [0xFF] then
+      IO.println "PASS"; passed := passed + 1
+    else
+      IO.println s!"FAIL: expected [255] (8-bit input mask), got {results} (issue #44 — likely 511, default W resolved to 32)"
+      failed := failed + 1
+  catch e => IO.println s!"FAIL: {e}"; failed := failed + 1
+
+  -- Test 34 (issue #45): casez `?` wildcards.
+  -- Bug: casez is routed through the same parseCaseBody as case, so
+  -- `?` in case items is compared as an ordinary bit (= 0) and the
+  -- wildcard arm never matches.
+  IO.print "  Test 34: casez `?` wildcards (issue #45)... "
+  try
+    let v := "
+module bug5_casez_wild (input clk, input [3:0] s, output [1:0] y);
+  reg [1:0] yr;
+  assign y = yr;
+  always @* begin
+    casez (s)
+      4'b1???: yr = 2'd3;
+      default: yr = 2'd0;
+    endcase
+  end
+endmodule
+"
+    -- s = 4'b1010 should match `4'b1???` arm → y = 3
+    let results ← jitRun v
+      (fun h => do JIT.setInput h 0 0b1010)
+      1
+      (fun h => do let v ← JIT.getOutput h 0; return [v])
+    if results == [3] then
+      IO.println "PASS"; passed := passed + 1
+    else
+      IO.println s!"FAIL: expected [3] for casez 4'b1??? match, got {results} (issue #45 — wildcard arm never fires)"
+      failed := failed + 1
+  catch e => IO.println s!"FAIL: {e}"; failed := failed + 1
+
   IO.println s!"\n=== Results: {passed} passed, {failed} failed ==="
   return if failed == 0 then 0 else 1

--- a/Tests/SVParser/ParserTest.lean
+++ b/Tests/SVParser/ParserTest.lean
@@ -1550,16 +1550,45 @@ endmodule
   -- multiply by 1 — a correctly-truncated module returns
   -- 0x1FF & 0xFF = 0xFF = 255, but with the 32-bit-wide port the
   -- full 0x1FF passes through.
-  IO.print "  Test 33: parameter default width truncates input (issue #44)... "
+  -- Diagnostic A: parameter default width — verbatim from the issue.
+  -- `[W-1:0] a` with default W = 8 should mask 0x1FF down to 0xFF;
+  -- if W resolves to 32 internally, 0x1FF leaks through.
+  IO.print "  Test 33a: parameter default width (issue #44 verbatim)... "
+  try
+    let v := "
+module param_default_width #(parameter W = 8) (input clk, input [W-1:0] a, output [W-1:0] y);
+  assign y = a + 1;
+endmodule
+"
+    -- a = 255 (0xFF).  Correct: 8-bit (a+1) wraps to 0.
+    -- Bug (W=32 internally): result = 256, low 8 bits = 0 — same value but for the wrong reason.
+    -- So feed 0x1FF instead: 8-bit input port should mask to 0xFF, (a+1) = 0; 32-bit port
+    -- leaks 0x1FF, (a+1) = 0x200, low 8 bits at the [W-1:0] output = 0 again.
+    -- The cleanest probe is to read `a` straight through: a 0x1FF input on an 8-bit
+    -- port → 0xFF out; on a 32-bit port → 0x1FF out.  We test that separately as 33.
+    -- Here we exercise the issue's literal repro and report the value either way.
+    let results ← jitRun v
+      (fun h => do JIT.setInput h 0 255)  -- 0xFF, fits in 8 bits
+      1
+      (fun h => do let v ← JIT.getOutput h 0; return [v])
+    -- With a = 0xFF and `assign y = a + 1`, an 8-bit lowering wraps to 0.
+    if results == [0] then
+      IO.println "PASS"; passed := passed + 1
+    else
+      IO.println s!"FAIL: expected [0] (8-bit wrap of 255+1), got {results} (issue #44)"
+      failed := failed + 1
+  catch e => IO.println s!"FAIL: {e}"; failed := failed + 1
+
+  -- Test 33b: same defect, but exposed via a value that distinguishes
+  -- 8-bit-masked input from 32-bit-passed-through input.  An 8-bit
+  -- port truncates 0x1FF to 0xFF (255); a 32-bit port forwards 0x1FF (511).
+  IO.print "  Test 33b: parameter default width truncates input (issue #44)... "
   try
     let v := "
 module bug4_param_default_width #(parameter W = 8) (input clk, input [W-1:0] a, output [15:0] y);
   assign y = a;
 endmodule
 "
-    -- We feed 0x1FF.  If the port were correctly 8-bit it should
-    -- mask to 0xFF = 255; if W resolved to 32 (the bug), the input
-    -- propagates as 0x1FF = 511.
     let results ← jitRun v
       (fun h => do JIT.setInput h 0 0x1FF)
       1
@@ -1567,7 +1596,29 @@ endmodule
     if results == [0xFF] then
       IO.println "PASS"; passed := passed + 1
     else
-      IO.println s!"FAIL: expected [255] (8-bit input mask), got {results} (issue #44 — likely 511, default W resolved to 32)"
+      IO.println s!"FAIL: expected [255] (8-bit input mask), got {results} (issue #44 — default W resolved to 32)"
+      failed := failed + 1
+  catch e => IO.println s!"FAIL: {e}"; failed := failed + 1
+
+  -- Test 33c: issue #44 symptom 2 — localparam constant-expression
+  -- width.  `K = 3 + 4` should resolve to 7; the bug truncates K to
+  -- 1-bit so `y = a + K` returns `a + 1` instead of `a + 7`.
+  IO.print "  Test 33c: localparam K = 3+4 width (issue #44 symptom 2)... "
+  try
+    let v := "
+module localparam_expr (input clk, input [7:0] a, output [7:0] y);
+  localparam K = 3 + 4;
+  assign y = a + K;
+endmodule
+"
+    let results ← jitRun v
+      (fun h => do JIT.setInput h 0 10)
+      1
+      (fun h => do let v ← JIT.getOutput h 0; return [v])
+    if results == [17] then
+      IO.println "PASS"; passed := passed + 1
+    else
+      IO.println s!"FAIL: expected [17] (10 + (3+4)), got {results} (issue #44 sympt. 2 — likely 11 = 10+1, K truncated)"
       failed := failed + 1
   catch e => IO.println s!"FAIL: {e}"; failed := failed + 1
 

--- a/Tests/SVParser/ParserTest.lean
+++ b/Tests/SVParser/ParserTest.lean
@@ -19,6 +19,12 @@ open Sparkle.Backend.Verilog
 open Sparkle.Backend.CppSim
 open Sparkle.Core.JIT
 
+-- The do-block of `main` is large enough that Lean's elaborator hits the
+-- default `maxRecDepth` (512) when it processes the trailing regression
+-- tests.  Bumping the budget keeps the whole file building without
+-- splitting tests into many `lean_exe` drivers.
+set_option maxRecDepth 1024
+
 def containsSubstr (s sub : String) : Bool :=
   (s.splitOn sub).length > 1
 
@@ -1619,6 +1625,109 @@ endmodule
       IO.println "PASS"; passed := passed + 1
     else
       IO.println s!"FAIL: expected [17] (10 + (3+4)), got {results} (issue #44 sympt. 2 — likely 11 = 10+1, K truncated)"
+      failed := failed + 1
+  catch e => IO.println s!"FAIL: {e}"; failed := failed + 1
+
+  -- ===================================================================
+  -- Tests 35-38: probe other 32-bit-hardcoded constants in
+  -- `Tools/SVParser/Lower.lean` that look like the issue-#41 family
+  -- (operand-width-blind constants used to build IR for reduction /
+  -- bitwise-NOT / logical-AND/OR / signed-extend lowerings).  If any
+  -- of these PASS today they are passive regression guards; if they
+  -- FAIL they are new bugs that warrant their own issues.
+  -- ===================================================================
+
+  -- Test 35: reduction-OR `|a` on a 4-bit operand.
+  -- Lower.lean line 155 uses a 32-bit `.const 0 32` for the
+  -- `(a != 0)` lowering.  With a 4-bit `a`, the wider zero may
+  -- still compare equal to a (truncated) zero, but the eq result
+  -- semantics aren't guaranteed when operand widths disagree.
+  IO.print "  Test 35: reduction-OR on 4-bit operand (Lower.lean:155)... "
+  try
+    let v := "
+module probe_redor (input clk, input [3:0] a, output y);
+  assign y = |a;
+endmodule
+"
+    -- a = 4'b0001 → expected 1 (any bit set)
+    -- a = 4'b0000 → expected 0
+    let r1 ← jitRun v (fun h => do JIT.setInput h 0 1) 1
+      (fun h => do let v ← JIT.getOutput h 0; return [v])
+    let r0 ← jitRun v (fun h => do JIT.setInput h 0 0) 1
+      (fun h => do let v ← JIT.getOutput h 0; return [v])
+    if r1 == [1] && r0 == [0] then
+      IO.println "PASS"; passed := passed + 1
+    else
+      IO.println s!"FAIL: a=1→{r1} a=0→{r0} (expected [1] and [0])"
+      failed := failed + 1
+  catch e => IO.println s!"FAIL: {e}"; failed := failed + 1
+
+  -- Test 36: logical-NOT `!a` on a 4-bit operand.
+  -- Lower.lean line 158 uses `.const 0 32` for the `(a == 0)`
+  -- lowering.  Same width-mismatch concern as Test 35.
+  IO.print "  Test 36: logical-NOT on 4-bit operand (Lower.lean:158)... "
+  try
+    let v := "
+module probe_lnot (input clk, input [3:0] a, output y);
+  assign y = !a;
+endmodule
+"
+    let r1 ← jitRun v (fun h => do JIT.setInput h 0 5) 1
+      (fun h => do let v ← JIT.getOutput h 0; return [v])
+    let r0 ← jitRun v (fun h => do JIT.setInput h 0 0) 1
+      (fun h => do let v ← JIT.getOutput h 0; return [v])
+    -- !5 = 0, !0 = 1
+    if r1 == [0] && r0 == [1] then
+      IO.println "PASS"; passed := passed + 1
+    else
+      IO.println s!"FAIL: !5→{r1} !0→{r0} (expected [0] and [1])"
+      failed := failed + 1
+  catch e => IO.println s!"FAIL: {e}"; failed := failed + 1
+
+  -- Test 37: bitwise-NOT `~a` on a 4-bit operand, observed via a
+  -- downstream `+`.  Lower.lean line 161 XORs the operand with a
+  -- 32-bit `-1` constant, so `~a` may carry the upper-28 bits
+  -- (set to 1 by the 32-bit XOR) into adjacent arithmetic.
+  IO.print "  Test 37: bitwise-NOT 4-bit, value-only check (Lower.lean:161)... "
+  try
+    let v := "
+module probe_bnot (input clk, input [3:0] a, output [4:0] y);
+  assign y = ~a + 1;
+endmodule
+"
+    -- a = 4'b0000; ~a = 4'b1111 = 15; 15 + 1 = 16 (5 bits clean)
+    -- bug: ~a as a 32-bit XOR = 0xFFFFFFFF; + 1 = 0x100000000 → low 5 bits = 0
+    let r ← jitRun v (fun h => do JIT.setInput h 0 0) 1
+      (fun h => do let v ← JIT.getOutput h 0; return [v])
+    if r == [16] then
+      IO.println "PASS"; passed := passed + 1
+    else
+      IO.println s!"FAIL: ~0+1 (4-bit) → {r}, expected [16]"
+      failed := failed + 1
+  catch e => IO.println s!"FAIL: {e}"; failed := failed + 1
+
+  -- Test 38: logical-AND `a && b` on 4-bit operands.
+  -- Lower.lean line 176-178 uses `.const 0 32` for both
+  -- `(lhs != 0)` and `(rhs != 0)` lowerings.
+  IO.print "  Test 38: logical-AND 4-bit operands (Lower.lean:176)... "
+  try
+    let v := "
+module probe_land (input clk, input [3:0] a, input [3:0] b, output y);
+  assign y = a && b;
+endmodule
+"
+    let r ← jitRun v
+      (fun h => do JIT.setInput h 0 3; JIT.setInput h 1 5)
+      1
+      (fun h => do let v ← JIT.getOutput h 0; return [v])
+    let r0 ← jitRun v
+      (fun h => do JIT.setInput h 0 0; JIT.setInput h 1 5)
+      1
+      (fun h => do let v ← JIT.getOutput h 0; return [v])
+    if r == [1] && r0 == [0] then
+      IO.println "PASS"; passed := passed + 1
+    else
+      IO.println s!"FAIL: 3&&5→{r}, 0&&5→{r0} (expected [1] and [0])"
       failed := failed + 1
   catch e => IO.println s!"FAIL: {e}"; failed := failed + 1
 

--- a/Tools/SVParser/AST.lean
+++ b/Tools/SVParser/AST.lean
@@ -84,20 +84,30 @@ inductive SVPortDir where
   | input | output | inout
   deriving Repr, BEq
 
-/-- Port declaration -/
+/-- Port declaration.
+
+    `width` is the *resolved* `(hi, lo)` pair (e.g. `(7, 0)` for an
+    8-bit port).  `widthExpr` is the *symbolic* pair captured at parse
+    time when either bound mentions a parameter — e.g. `[W-1:0]`
+    becomes `widthExpr = some (W-1, 0)` while `width` falls back to
+    the parser's `(31, 0)` default.  Lower-time param substitution
+    resolves `widthExpr` against the param value map and overwrites
+    `width`. -/
 structure SVPort where
   dir    : SVPortDir
   isReg  : Bool := false            -- output reg
   width  : Option (Nat × Nat)       -- [hi:lo] or none for 1-bit
   name   : String
+  widthExpr : Option (SVExpr × SVExpr) := none  -- symbolic [hi:lo] before param subst
   deriving Repr, BEq
 
 /-- Parameter declaration -/
 structure SVParam where
-  name     : String
-  width    : Option (Nat × Nat)     -- optional [hi:lo]
-  value    : SVExpr                 -- default value expression
-  isLocal  : Bool := false          -- localparam vs parameter
+  name      : String
+  width     : Option (Nat × Nat)     -- optional [hi:lo]
+  value     : SVExpr                 -- default value expression
+  isLocal   : Bool := false          -- localparam vs parameter
+  widthExpr : Option (SVExpr × SVExpr) := none  -- symbolic [hi:lo] before param subst
   deriving Repr, BEq
 
 /-- Module-level items -/

--- a/Tools/SVParser/AST.lean
+++ b/Tools/SVParser/AST.lean
@@ -92,13 +92,19 @@ inductive SVPortDir where
     becomes `widthExpr = some (W-1, 0)` while `width` falls back to
     the parser's `(31, 0)` default.  Lower-time param substitution
     resolves `widthExpr` against the param value map and overwrites
-    `width`. -/
+    `width`.
+
+    `isSigned` records whether the declaration carried the `signed`
+    keyword (e.g. `input signed [7:0] a`).  Used by the lowering pass
+    to choose between unsigned (`lt_u`) and signed (`lt_s`) IR
+    operators in relational comparisons. -/
 structure SVPort where
-  dir    : SVPortDir
-  isReg  : Bool := false            -- output reg
-  width  : Option (Nat × Nat)       -- [hi:lo] or none for 1-bit
-  name   : String
+  dir       : SVPortDir
+  isReg     : Bool := false            -- output reg
+  width     : Option (Nat × Nat)       -- [hi:lo] or none for 1-bit
+  name      : String
   widthExpr : Option (SVExpr × SVExpr) := none  -- symbolic [hi:lo] before param subst
+  isSigned  : Bool := false                     -- `signed` keyword present?
   deriving Repr, BEq
 
 /-- Parameter declaration -/

--- a/Tools/SVParser/AST.lean
+++ b/Tools/SVParser/AST.lean
@@ -16,6 +16,11 @@ inductive SVLiteral where
   | decimal (width : Option Nat) (value : Nat)
   | hex     (width : Option Nat) (value : Nat)
   | binary  (width : Option Nat) (value : Nat)
+  /-- `casez`-style binary literal with `?` wildcards (e.g. `4'b1???`).
+      `value` keeps the non-`?` bits set, `mask` has a 1 in every `?`
+      position (i.e. "bits to ignore when comparing").  Equivalent to
+      a plain `binary` when `mask = 0`. -/
+  | binaryWild (width : Nat) (value : Nat) (mask : Nat)
   deriving Repr, BEq
 
 /-- Unary operators -/

--- a/Tools/SVParser/Lexer.lean
+++ b/Tools/SVParser/Lexer.lean
@@ -315,17 +315,65 @@ def eqSign   : P Unit := token (matchStr "=")
 def qmark    : P Unit := token (matchStr "?")
 def op2 (s : String) : P Unit := token (matchStr s)
 
-/-- Parse a bit range [hi:lo]. For parameterized widths like [N-1:0],
-    skip over identifiers and treat as [31:0] (default 32-bit). -/
-def bitRange : P (Nat × Nat) := do
+/-- Identifier reader used by `bitRange` for parameter references like
+    `W` in `[W-1:0]`.  Reads a single Verilog identifier (letter/underscore
+    followed by letter/digit/underscore), tokenized (skips trailing ws). -/
+def parseIdentSimple : P String := token do
+  let first ← nextChar
+  if !(first.isAlpha || first == '_') then
+    fail s!"expected identifier, got '{first}'"
+  let mut result : List Char := [first]
+  let mut cont := true
+  while cont do
+    let c ← peekChar
+    match c with
+    | some c' =>
+      if c'.isAlphanum || c' == '_' then
+        let _ ← nextChar; result := result ++ [c']
+      else cont := false
+    | none => cont := false
+  pure (String.ofList result)
+
+/-- Parse a bit range `[hi:lo]`.
+
+    Returns the *resolved* `(hi, lo)` pair when both bounds are
+    numeric, plus an optional **symbolic** form when either bound
+    mentions an identifier (parameter reference).  The symbolic form
+    lets the lowering pass evaluate `[W-1:0]` against the actual
+    parameter map instead of falling back to the historic 31:0
+    placeholder.
+
+    Recognised shapes:
+      `[<num>:<num>]`                        — concrete
+      `[<num>±<num>:<num>±<num>]`            — concrete
+      `[<ident>:<num>]`                      — symbolic
+      `[<ident>±<num>:<num>±<num>]`          — symbolic
+      `[<ident>:<ident>]` (etc.)             — symbolic
+
+    The lexer can build the symbolic `SVExpr` directly because the
+    forms it needs (`ident`, `lit decimal`, `binary sub/add`) are all
+    in scope through `import Tools.SVParser.AST` — no recursion into
+    the full Parser is required. -/
+def bitRange : P ((Nat × Nat) × Option (SVExpr × SVExpr)) := do
   lbracket
-  let hi ← parseBitRangeVal
+  let (hiN, hiE) ← parseBitRangeVal
   colon
-  let lo ← parseBitRangeVal
+  let (loN, loE) ← parseBitRangeVal
   rbracket
-  pure (hi, lo)
+  let exprForm := if hiE.isSome || loE.isSome then
+    -- At least one bound mentions an identifier; capture both as
+    -- symbolic expressions so the lowering can substitute params.
+    let toExpr : Option SVExpr → Nat → SVExpr := fun oe n =>
+      oe.getD (.lit (.decimal none n))
+    some (toExpr hiE hiN, toExpr loE loN)
+  else none
+  pure ((hiN, loN), exprForm)
 where
-  parseBitRangeVal : P Nat := do
+  /-- Parse a single bound.  Returns `(fallbackNat, symbolicExpr?)` —
+      the fallback is what the historic parser would have produced
+      (always-31 for any identifier-bearing bound), and the symbolic
+      `SVExpr` is non-`none` when the bound involves an identifier. -/
+  parseBitRangeVal : P (Nat × Option SVExpr) := do
     let c ← peekChar
     if c.map isDigit == some true then
       let d ← token digits
@@ -333,16 +381,35 @@ where
       match ← attempt (token (matchStr "-")) with
       | some _ =>
         let sub ← token digits
-        pure (d.toNat! - sub.toNat!)
+        pure (d.toNat! - sub.toNat!, none)
       | none =>
         match ← attempt (token (matchStr "+")) with
-        | some _ => let add ← token digits; pure (d.toNat! + add.toNat!)
-        | none => pure d.toNat!
-    else
-      -- Identifier-based expression (e.g., regindex_bits-1)
-      -- Skip until : or ]
+        | some _ => let add ← token digits; pure (d.toNat! + add.toNat!, none)
+        | none => pure (d.toNat!, none)
+    else if c.map (fun c => c.isAlpha || c == '_') == some true then
+      -- Identifier-based expression.  Build a real SVExpr for `ident`,
+      -- `ident - n`, `ident + n` (and chains thereof) so the lowering
+      -- can substitute params.  Anything more complex than that falls
+      -- back to skipping (preserves prior behaviour for cases we don't
+      -- explicitly model yet).
+      let name ← parseIdentSimple
+      let mut acc : SVExpr := .ident name
+      let mut cont := true
+      while cont do
+        match ← attempt (token (matchStr "-")) with
+        | some _ =>
+          let d ← token digits
+          acc := .binary .sub acc (.lit (.decimal none d.toNat!))
+        | none =>
+          match ← attempt (token (matchStr "+")) with
+          | some _ =>
+            let d ← token digits
+            acc := .binary .add acc (.lit (.decimal none d.toNat!))
+          | none => cont := false
+      -- After the simple expression, if any unexpected char remains
+      -- before `:` or `]`, skip it (preserving prior behaviour for
+      -- complex identifier-bearing widths we can't yet symbolify).
       let mut depth : Nat := 0
-      let mut result : Nat := 31  -- default
       let mut running := true
       while running do
         let ch ← peekChar
@@ -353,7 +420,22 @@ where
         | some _ => let _ ← nextChar
         | none => running := false
       ws
-      pure result
+      pure (31, some acc)  -- fallback Nat = 31 (historic); symbolic acc available
+    else
+      -- Fallback: skip until : or ] (historic behaviour, fallback 31).
+      let mut depth : Nat := 0
+      let mut result : Nat := 31
+      let mut running := true
+      while running do
+        let ch ← peekChar
+        match ch with
+        | some ':' => if depth == 0 then running := false else let _ ← nextChar
+        | some ']' => if depth == 0 then running := false else let _ ← nextChar
+        | some '[' => let _ ← nextChar; depth := depth + 1
+        | some _ => let _ ← nextChar
+        | none => running := false
+      ws
+      pure (result, none)
 
 -- ============================================================================
 -- Repetition helpers

--- a/Tools/SVParser/Lexer.lean
+++ b/Tools/SVParser/Lexer.lean
@@ -206,6 +206,36 @@ def binDigitsStr : P String := do
     | none => cont := false
   pure (String.ofList result)
 
+/-- Like `binDigitsStr` but also accepts `?` characters (interpreted as
+    don't-care bits — required for `casez`-style wildcard literals like
+    `4'b1???`).  Underscores between digits are allowed too. -/
+def binDigitsOrWildcardStr : P String := do
+  let first ← nextChar
+  if !(isBinDigit first || first == '?') then
+    fail s!"expected binary digit or '?', got '{first}'"
+  let mut result : List Char := [first]
+  let mut cont := true
+  while cont do
+    let c ← peekChar
+    match c with
+    | some c' =>
+      if isBinDigit c' || c' == '?' then
+        let _ ← nextChar; result := result ++ [c']
+      else if c' == '_' then
+        let _ ← nextChar  -- skip underscores
+      else cont := false
+    | none => cont := false
+  pure (String.ofList result)
+
+/-- Compute `(value, mask)` from a binary digit string that may contain
+    `?` wildcards.  Each `?` contributes a 1 in `mask` and 0 in `value`. -/
+def binWildToValMask (s : String) : Nat × Nat :=
+  s.foldl (fun (v, m) c =>
+    let bit := if c == '1' then 1 else 0
+    let mbit := if c == '?' then 1 else 0
+    (v * 2 + bit, m * 2 + mbit)
+  ) (0, 0)
+
 def hexToNat (s : String) : Nat :=
   s.foldl (fun acc c =>
     let d := if '0' ≤ c && c ≤ '9' then c.toNat - '0'.toNat
@@ -256,8 +286,12 @@ def numericLiteral : P SVLiteral := token do
       pure (SVLiteral.decimal (some d.toNat!) dd.toNat!)
     | 'b' | 'B' =>
       skipUnderscoresAndSpaces
-      let bd ← binDigitsStr
-      pure (SVLiteral.binary (some d.toNat!) (binToNat bd))
+      let bd ← binDigitsOrWildcardStr
+      if bd.any (· == '?') then
+        let (v, m) := binWildToValMask bd
+        pure (SVLiteral.binaryWild d.toNat! v m)
+      else
+        pure (SVLiteral.binary (some d.toNat!) (binToNat bd))
     | _ => fail s!"unknown base '{base}'"
   else
     pure (SVLiteral.decimal none d.toNat!)

--- a/Tools/SVParser/Lower.lean
+++ b/Tools/SVParser/Lower.lean
@@ -96,6 +96,9 @@ def literalToConst : SVLiteral → Expr
   | .hex none v         => .const (Int.ofNat v) 32
   | .binary (some w) v  => .const (Int.ofNat v) w
   | .binary none v      => .const (Int.ofNat v) 32
+  -- `binaryWild` outside a `casez` arm: drop the mask (Verilog semantics
+  -- for `?`/`x`/`z` in plain expressions are undefined; treat as 0).
+  | .binaryWild w v _   => .const (Int.ofNat v) w
 
 /-- Set of array-typed register names for distinguishing bit-select vs array access -/
 private def arrayNames : List String := []  -- populated per-module during lowering
@@ -140,6 +143,7 @@ private def concatWidth : SVExpr → Nat
   | .lit (.decimal none _) => 32
   | .lit (.hex none _) => 32
   | .lit (.binary none _) => 1
+  | .lit (.binaryWild w _ _) => w  -- casez wildcard: width is always explicit
   | _ => 32  -- default: assume 32-bit
 
 partial def lowerExpr (e : SVExpr) : Expr :=
@@ -424,15 +428,31 @@ private def decomposeMultiConcatLhs (lhs : SVExpr) (rhs : SVExpr) : List (String
 
 /-- Build a case arm condition from labels and selector.
     For case(1'b1), labels are direct conditions (priority encoding).
-    For normal case, labels are compared against sel. -/
+    For normal case, labels are compared against sel.
+    For `casez`-style wildcard literals (`SVLiteral.binaryWild`) the
+    comparison ignores bits marked as don't-care in the mask:
+        ((sel ^ value) & ~mask) == 0 -/
 private def mkCaseCond (sel : SVExpr) (labels : List SVExpr) : Expr :=
   let isCase1b1 := match sel with
     | .lit (.binary (some 1) 1) => true
     | .lit (.decimal (some 1) 1) => true
     | _ => false
+  let selExpr := lowerExpr sel
+  let oneCond : SVExpr → Expr := fun label =>
+    match label with
+    | .lit (.binaryWild w v m) =>
+      -- (sel ^ value) & ~mask == 0
+      let notMask := (2^w - 1).xor m  -- ~mask, sized to w
+      let valExpr := Expr.const (Int.ofNat v) w
+      let maskExpr := Expr.const (Int.ofNat notMask) w
+      Expr.op .eq
+        [Expr.op .and [Expr.op .xor [selExpr, valExpr], maskExpr],
+         Expr.const 0 w]
+    | _ =>
+      if isCase1b1 then lowerExpr label
+      else Expr.op .eq [selExpr, lowerExpr label]
   labels.foldl (fun acc label =>
-    let c := if isCase1b1 then lowerExpr label
-             else Expr.op .eq [lowerExpr sel, lowerExpr label]
+    let c := oneCond label
     if acc == Expr.const 0 1 then c else Expr.op .or [acc, c]
   ) (Expr.const 0 1)
 

--- a/Tools/SVParser/Lower.lean
+++ b/Tools/SVParser/Lower.lean
@@ -1067,6 +1067,20 @@ partial def evalConstExpr (paramVals : List (String × Nat)) : SVExpr → Option
     let va ← evalConstExpr paramVals a
     let vb ← evalConstExpr paramVals b
     some (va ||| vb)
+  | .binary .add a b => do
+    let va ← evalConstExpr paramVals a
+    let vb ← evalConstExpr paramVals b
+    some (va + vb)
+  | .binary .sub a b => do
+    let va ← evalConstExpr paramVals a
+    let vb ← evalConstExpr paramVals b
+    -- Nat subtraction is saturating at 0, which is exactly what we want
+    -- for bit-range bounds (negative widths are nonsensical anyway).
+    some (va - vb)
+  | .binary .mul a b => do
+    let va ← evalConstExpr paramVals a
+    let vb ← evalConstExpr paramVals b
+    some (va * vb)
   | .unary .logNot a => do
     let va ← evalConstExpr paramVals a
     some (if va == 0 then 1 else 0)
@@ -1388,7 +1402,18 @@ def lowerModule (svMod : SVModule) (paramOverrides : List (String × Nat) := [])
     match paramVals.find? fun (n, _) => n == p.name with
     | some (_, v) => { p with value := .lit (.decimal (some 32) v) }
     | none => p
-  let svMod := { svMod with items := expandedItems, params := svParams }
+  -- Resolve symbolic port widths (e.g. `[W-1:0]`) against the resolved
+  -- parameter values.  Without this, the parser's `bitRange` falls back
+  -- to a 32-bit placeholder for any identifier-bearing bound, which
+  -- breaks parameters that were intended to size ports (issue #44).
+  let resolvedPorts := svMod.ports.map fun p =>
+    match p.widthExpr with
+    | none => p  -- already concrete
+    | some (hiE, loE) =>
+      match evalConstExpr paramVals hiE, evalConstExpr paramVals loE with
+      | some hiV, some loV => { p with width := some (hiV, loV) }
+      | _, _ => p  -- couldn't resolve; keep the parser's fallback
+  let svMod := { svMod with items := expandedItems, params := svParams, ports := resolvedPorts }
 
   -- Build environment
   let mut env := LowerEnv.empty

--- a/Tools/SVParser/Lower.lean
+++ b/Tools/SVParser/Lower.lean
@@ -42,11 +42,13 @@ def widthToBits : Option (Nat × Nat) → Nat
 -- ============================================================================
 
 structure LowerEnv where
-  portWidths : List (String × Option (Nat × Nat))  -- port name → width
-  wireWidths : List (String × Option (Nat × Nat))  -- wire name → width
-  regNames   : List String                          -- names declared as reg
+  portWidths  : List (String × Option (Nat × Nat))  -- port name → width
+  wireWidths  : List (String × Option (Nat × Nat))  -- wire name → width
+  regNames    : List String                          -- names declared as reg
+  signedNames : List String := []                    -- ports declared `signed`
 
-def LowerEnv.empty : LowerEnv := { portWidths := [], wireWidths := [], regNames := [] }
+def LowerEnv.empty : LowerEnv :=
+  { portWidths := [], wireWidths := [], regNames := [], signedNames := [] }
 
 def LowerEnv.getWidth (env : LowerEnv) (name : String) : Option (Nat × Nat) :=
   (env.portWidths.find? (·.1 == name) |>.map (·.2)).join <|>
@@ -57,6 +59,14 @@ def LowerEnv.getHWType (env : LowerEnv) (name : String) : HWType :=
 
 def LowerEnv.isReg (env : LowerEnv) (name : String) : Bool :=
   env.regNames.any (· == name)
+
+/-- Conservative signedness inference for SV expressions: an expression
+    is *signed* iff its top-level operand reaches a declared-`signed`
+    port or wire.  Mirrors Verilog's "context-determined" signedness
+    only in the common operand-ref case; sub-expressions involving
+    arithmetic are treated as unsigned (matches IR `op` semantics). -/
+def LowerEnv.isSignedRef (env : LowerEnv) (name : String) : Bool :=
+  env.signedNames.any (· == name)
 
 -- ============================================================================
 -- Expression lowering
@@ -1380,6 +1390,76 @@ private def narrowMaskStmt (env : LowerEnv) : Stmt → Stmt
       (conns.map fun (p, e) => (p, narrowMaskConstants env e))
 
 -- ============================================================================
+-- Post-pass: promote unsigned relational ops (`<`, `<=`, `>`, `>=`) to
+-- their signed counterparts when at least one operand is a reference to
+-- a port declared with the SystemVerilog `signed` keyword.
+--
+-- `lowerExpr` always emits `.lt_u` / `.le_u` / `.gt_u` / `.ge_u` because
+-- it can't see the surrounding `LowerEnv`.  Without this fix-up, a
+-- comparison of two `signed [7:0]` ports is performed as unsigned and
+-- e.g. `(-106) < 127` returns 0 (issue #43, Test 32).
+-- ============================================================================
+
+/-- Does this IR expression reach a signed port reference at its leaf
+    operand position?  Conservative — only `.ref` chains and trivial
+    slices propagate signedness; arithmetic mixes lose it (which
+    matches the IR's own context-determined arithmetic semantics). -/
+private partial def exprHasSignedLeaf (env : LowerEnv) : Expr → Bool
+  | .ref name => env.isSignedRef name
+  | .slice e _ _ => exprHasSignedLeaf env e
+  | _ => false
+
+/-- Rewrite each `lt_u`/`le_u`/`gt_u`/`ge_u` to the signed counterpart
+    when either argument references a signed port. -/
+private partial def promoteSignedComparisons (env : LowerEnv) : Expr → Expr
+  | .op .lt_u [a, b] =>
+    let a' := promoteSignedComparisons env a
+    let b' := promoteSignedComparisons env b
+    let op := if exprHasSignedLeaf env a' || exprHasSignedLeaf env b' then
+              Sparkle.IR.AST.Operator.lt_s else Sparkle.IR.AST.Operator.lt_u
+    .op op [a', b']
+  | .op .le_u [a, b] =>
+    let a' := promoteSignedComparisons env a
+    let b' := promoteSignedComparisons env b
+    let op := if exprHasSignedLeaf env a' || exprHasSignedLeaf env b' then
+              Sparkle.IR.AST.Operator.le_s else Sparkle.IR.AST.Operator.le_u
+    .op op [a', b']
+  | .op .gt_u [a, b] =>
+    let a' := promoteSignedComparisons env a
+    let b' := promoteSignedComparisons env b
+    let op := if exprHasSignedLeaf env a' || exprHasSignedLeaf env b' then
+              Sparkle.IR.AST.Operator.gt_s else Sparkle.IR.AST.Operator.gt_u
+    .op op [a', b']
+  | .op .ge_u [a, b] =>
+    let a' := promoteSignedComparisons env a
+    let b' := promoteSignedComparisons env b
+    let op := if exprHasSignedLeaf env a' || exprHasSignedLeaf env b' then
+              Sparkle.IR.AST.Operator.ge_s else Sparkle.IR.AST.Operator.ge_u
+    .op op [a', b']
+  | .op o args => .op o (args.map (promoteSignedComparisons env))
+  | .concat args => .concat (args.map (promoteSignedComparisons env))
+  | .slice e hi lo => .slice (promoteSignedComparisons env e) hi lo
+  | .index arr idx =>
+    .index (promoteSignedComparisons env arr) (promoteSignedComparisons env idx)
+  | e => e
+
+/-- Apply `promoteSignedComparisons` to every `Expr` stored in a `Stmt`. -/
+private def promoteSignedStmt (env : LowerEnv) : Stmt → Stmt
+  | .assign lhs rhs => .assign lhs (promoteSignedComparisons env rhs)
+  | .register output clk rst input init =>
+    .register output clk rst (promoteSignedComparisons env input) init
+  | .memory name aw dw clk wa wd we ra rd cr =>
+    .memory name aw dw clk
+      (promoteSignedComparisons env wa)
+      (promoteSignedComparisons env wd)
+      (promoteSignedComparisons env we)
+      (promoteSignedComparisons env ra)
+      rd cr
+  | .inst modName instName conns =>
+    .inst modName instName
+      (conns.map fun (p, e) => (p, promoteSignedComparisons env e))
+
+-- ============================================================================
 -- Module lowering
 -- ============================================================================
 
@@ -1419,6 +1499,8 @@ def lowerModule (svMod : SVModule) (paramOverrides : List (String × Nat) := [])
   let mut env := LowerEnv.empty
   for p in svMod.ports do
     env := { env with portWidths := env.portWidths ++ [(p.name, p.width)] }
+    if p.isSigned then
+      env := { env with signedNames := env.signedNames ++ [p.name] }
   for item in svMod.items do
     match item with
     | .wireDecl name width _ => env := { env with wireWidths := env.wireWidths ++ [(name, width)] }
@@ -1732,16 +1814,24 @@ def lowerModule (svMod : SVModule) (paramOverrides : List (String × Nat) := [])
         assertIdx := assertIdx + 1
     | _ => pure ()
 
-  -- Refinement pass: narrow the 32-bit all-ones mask emitted for
-  -- bitwise-NOT (`~x`) to the operand's actual width when known.
-  -- See the comment above `narrowMaskConstants` for the rationale.
+  -- Refinement passes (strictly additive — only rewrite shapes we
+  -- explicitly recognise, leave everything else alone):
+  --   1. narrowMaskStmt:        narrow `lowerExpr`'s 32-bit `~x` mask
+  --                             to the operand's actual width (Test 37,
+  --                             plus incidentally fixes issue #41 /
+  --                             Test 30).
+  --   2. promoteSignedStmt:     rewrite `lt_u`/`le_u`/`gt_u`/`ge_u` to
+  --                             their `_s` counterparts when either
+  --                             arg references a `signed` port
+  --                             (issue #43 / Test 32).
   let narrowedBody := dedupBody.map (narrowMaskStmt env)
+  let promotedBody := narrowedBody.map (promoteSignedStmt env)
   pure {
     name := svMod.name
     inputs := inputs
     outputs := outputs
     wires := dedupWires
-    body := topoSortBody narrowedBody
+    body := topoSortBody promotedBody
     assertions := assertions
     isPrimitive := false
   }

--- a/Tools/SVParser/Lower.lean
+++ b/Tools/SVParser/Lower.lean
@@ -1285,6 +1285,67 @@ partial def expandGenerateBlocks (paramVals : List (String × Nat))
     | other => [other]
 
 -- ============================================================================
+-- Post-pass: narrow the 32-bit all-ones mask that `lowerExpr` emits for
+-- bitwise-NOT (`~x`).  When the operand `x` is a known port/wire/reg, we
+-- can replace the 32-bit constant with one matching the operand's actual
+-- width.  Without this pass, `~a + 1` with `a : [3:0]` (Test 37 of
+-- `Tests/SVParser/ParserTest.lean`) returns 0 instead of 16 because the
+-- upper 28 bits of `~a` are set and the +1 carry propagates through them.
+--
+-- The pass is a *strict refinement*: any expression shape it does not
+-- recognise (or any operand whose width cannot be determined from the
+-- existing `LowerEnv`) falls through unchanged, so the rest of the IR
+-- corpus cannot regress.
+--
+-- We intentionally do NOT also narrow the matching reductAnd / logNot /
+-- logAnd / logOr constants — they share the same 32-bit-constant family
+-- (issue #41) but require narrowing both an XOR mask and a separate
+-- equality comparator together to stay sound.  That is a follow-up PR.
+-- ============================================================================
+
+/-- Best-effort width inference for an IR `Expr` against the lowering
+    environment.  Returns `none` when the operand's width can't be
+    determined locally; the caller treats `none` as "leave the constant
+    alone". -/
+private def exprWidthForNarrow (env : LowerEnv) : Expr → Option Nat
+  | .ref name => (env.getWidth name).map (fun (hi, lo) => hi - lo + 1)
+  | .const _ w => some w
+  | .slice _ hi lo => some (hi - lo + 1)
+  | _ => none
+
+/-- Rewrite the `(x XOR <32-bit -1>)` shape emitted by `lowerExpr` for
+    bitwise-NOT so the all-ones constant matches the inferred width of
+    `x`.  Recurse structurally so the rewrite reaches nested
+    sub-expressions. -/
+private partial def narrowMaskConstants (env : LowerEnv) : Expr → Expr
+  | .op .xor [a, .const (-1) 32] =>
+    let a' := narrowMaskConstants env a
+    match exprWidthForNarrow env a' with
+    | some w => .op .xor [a', .const (-1) w]
+    | none   => .op .xor [a', .const (-1) 32]
+  | .op o args => .op o (args.map (narrowMaskConstants env))
+  | .concat args => .concat (args.map (narrowMaskConstants env))
+  | .slice e hi lo => .slice (narrowMaskConstants env e) hi lo
+  | .index arr idx => .index (narrowMaskConstants env arr) (narrowMaskConstants env idx)
+  | e => e
+
+/-- Apply `narrowMaskConstants` to every `Expr` field stored in a `Stmt`. -/
+private def narrowMaskStmt (env : LowerEnv) : Stmt → Stmt
+  | .assign lhs rhs => .assign lhs (narrowMaskConstants env rhs)
+  | .register output clk rst input init =>
+    .register output clk rst (narrowMaskConstants env input) init
+  | .memory name aw dw clk wa wd we ra rd cr =>
+    .memory name aw dw clk
+      (narrowMaskConstants env wa)
+      (narrowMaskConstants env wd)
+      (narrowMaskConstants env we)
+      (narrowMaskConstants env ra)
+      rd cr
+  | .inst modName instName conns =>
+    .inst modName instName
+      (conns.map fun (p, e) => (p, narrowMaskConstants env e))
+
+-- ============================================================================
 -- Module lowering
 -- ============================================================================
 
@@ -1626,12 +1687,16 @@ def lowerModule (svMod : SVModule) (paramOverrides : List (String × Nat) := [])
         assertIdx := assertIdx + 1
     | _ => pure ()
 
+  -- Refinement pass: narrow the 32-bit all-ones mask emitted for
+  -- bitwise-NOT (`~x`) to the operand's actual width when known.
+  -- See the comment above `narrowMaskConstants` for the rationale.
+  let narrowedBody := dedupBody.map (narrowMaskStmt env)
   pure {
     name := svMod.name
     inputs := inputs
     outputs := outputs
     wires := dedupWires
-    body := topoSortBody dedupBody
+    body := topoSortBody narrowedBody
     assertions := assertions
     isPrimitive := false
   }

--- a/Tools/SVParser/Lower.lean
+++ b/Tools/SVParser/Lower.lean
@@ -2007,10 +2007,22 @@ def lowerDesign (svDesign : SVDesign) : Except String Design := do
   for m in svDesign.modules do
     let lowered ← lowerModule m
     modules := modules ++ [lowered]
-  -- Use first module as top (flat wrapper is first, sub-modules follow)
-  let topName := match svDesign.modules.head? with
-    | some m => m.name
-    | none => "top"
+  -- Pick the top module: prefer the module that is NOT instantiated by
+  -- any other (so source order doesn't matter — a designer can declare
+  -- sub-modules either before or after the top).  Fall back to the
+  -- first module when every module is instantiated (e.g. mutual
+  -- instantiation, which Sparkle doesn't really support anyway).
+  --
+  -- This also avoids issue #42, where putting `module inc` before
+  -- `module bug2_chained_inst` made the flattener treat `inc` as the
+  -- top and silently drop the chained-instance design.
+  let instantiated : List String := modules.flatMap fun m =>
+    m.body.filterMap fun s => match s with
+      | .inst modName _ _ => some modName
+      | _ => none
+  let topName :=
+    (modules.find? fun m => !instantiated.contains m.name) |>.map (·.name)
+      |>.getD (modules.head?.map (·.name) |>.getD "top")
   pure { topModule := topName, modules }
 
 -- ============================================================================

--- a/Tools/SVParser/Parser.lean
+++ b/Tools/SVParser/Parser.lean
@@ -482,10 +482,10 @@ def parsePortInList : P SVPort := do
   let isReg ← match ← attempt (keyword "reg") with | some _ => pure true | none => pure false
   let _ ← attempt (keyword "logic")
   let _ ← attempt (keyword "wire")
-  let _ ← attempt (keyword "signed")
+  let isSigned := match ← attempt (keyword "signed") with | some _ => true | none => false
   let (width, widthExpr) ← parseOptWidthSym
   let name ← identifier
-  pure { dir, isReg, width, name, widthExpr }
+  pure { dir, isReg, width, name, widthExpr, isSigned }
 
 /-- Parse port list with direction carry-over.
     In Verilog, `input clk, resetn` means both are inputs.
@@ -498,6 +498,7 @@ def parsePortList : P (List SVPort) := do
   let mut lastIsReg := first.isReg
   let mut lastWidth := first.width
   let mut lastWidthExpr := first.widthExpr
+  let mut lastIsSigned := first.isSigned
   let mut cont := true
   while cont do
     match ← attempt comma with
@@ -509,24 +510,26 @@ def parsePortList : P (List SVPort) := do
         lastIsReg := match ← attempt (keyword "reg") with | some _ => true | none => false
         let _ ← attempt (keyword "logic")
         let _ ← attempt (keyword "wire")
-        let _ ← attempt (keyword "signed")
+        lastIsSigned := match ← attempt (keyword "signed") with | some _ => true | none => false
         let (w, we) ← parseOptWidthSym
         lastWidth := w
         lastWidthExpr := we
         let name ← identifier
         let port := { dir := lastDir, isReg := lastIsReg, width := lastWidth,
-                      widthExpr := lastWidthExpr, name : SVPort }
+                      widthExpr := lastWidthExpr, isSigned := lastIsSigned,
+                      name : SVPort }
         ports := ports ++ [port]
       | none =>
         -- No direction keyword — carry over from previous
-        let _ ← attempt (keyword "signed")
+        let newSigned := match ← attempt (keyword "signed") with | some _ => true | none => lastIsSigned
         -- Check for new width override
         let (width, widthExpr) ← parseOptWidthSym
         let w := if width.isSome then width else lastWidth
         let we := if width.isSome then widthExpr else lastWidthExpr
         let name ← identifier
         let port := { dir := lastDir, isReg := lastIsReg, width := w,
-                      widthExpr := we, name : SVPort }
+                      widthExpr := we, isSigned := newSigned,
+                      name : SVPort }
         ports := ports ++ [port]
     | none => cont := false
   rparen; pure ports

--- a/Tools/SVParser/Parser.lean
+++ b/Tools/SVParser/Parser.lean
@@ -464,7 +464,17 @@ def parsePortDir : P SVPortDir := do
 
 def parseOptWidth : P (Option (Nat × Nat)) := do
   match ← attempt bitRange with
-  | some r => pure (some r) | none => pure none
+  | some (r, _) => pure (some r) | none => pure none
+
+/-- Same as `parseOptWidth` but also returns the symbolic
+    `(hiExpr, loExpr)` form when either bound of the range mentioned
+    an identifier (parameter reference).  Used by the port / param /
+    wire / reg declaration parsers so the lowering pass can resolve
+    `[W-1:0]` against the parameter value map. -/
+def parseOptWidthSym : P (Option (Nat × Nat) × Option (SVExpr × SVExpr)) := do
+  match ← attempt bitRange with
+  | some (r, sym) => pure (some r, sym)
+  | none => pure (none, none)
 
 /-- Parse a port: direction [reg] [width] name -/
 def parsePortInList : P SVPort := do
@@ -473,9 +483,9 @@ def parsePortInList : P SVPort := do
   let _ ← attempt (keyword "logic")
   let _ ← attempt (keyword "wire")
   let _ ← attempt (keyword "signed")
-  let width ← parseOptWidth
+  let (width, widthExpr) ← parseOptWidthSym
   let name ← identifier
-  pure { dir, isReg, width, name }
+  pure { dir, isReg, width, name, widthExpr }
 
 /-- Parse port list with direction carry-over.
     In Verilog, `input clk, resetn` means both are inputs.
@@ -487,6 +497,7 @@ def parsePortList : P (List SVPort) := do
   let mut lastDir := first.dir
   let mut lastIsReg := first.isReg
   let mut lastWidth := first.width
+  let mut lastWidthExpr := first.widthExpr
   let mut cont := true
   while cont do
     match ← attempt comma with
@@ -499,18 +510,23 @@ def parsePortList : P (List SVPort) := do
         let _ ← attempt (keyword "logic")
         let _ ← attempt (keyword "wire")
         let _ ← attempt (keyword "signed")
-        lastWidth ← parseOptWidth
+        let (w, we) ← parseOptWidthSym
+        lastWidth := w
+        lastWidthExpr := we
         let name ← identifier
-        let port := { dir := lastDir, isReg := lastIsReg, width := lastWidth, name : SVPort }
+        let port := { dir := lastDir, isReg := lastIsReg, width := lastWidth,
+                      widthExpr := lastWidthExpr, name : SVPort }
         ports := ports ++ [port]
       | none =>
         -- No direction keyword — carry over from previous
         let _ ← attempt (keyword "signed")
         -- Check for new width override
-        let width ← parseOptWidth
+        let (width, widthExpr) ← parseOptWidthSym
         let w := if width.isSome then width else lastWidth
+        let we := if width.isSome then widthExpr else lastWidthExpr
         let name ← identifier
-        let port := { dir := lastDir, isReg := lastIsReg, width := w, name : SVPort }
+        let port := { dir := lastDir, isReg := lastIsReg, width := w,
+                      widthExpr := we, name : SVPort }
         ports := ports ++ [port]
     | none => cont := false
   rparen; pure ports


### PR DESCRIPTION
Adds reproduction tests for the five open SV→Sparkle transpiler
defects #41–#45 and lands the fixes for each.  All five tests now
pass.

## Final score

`lake exe svparser-test`: **40 passed, 0 failed**.

| Test | Issue | Construct | Status |
|------|-------|-----------|--------|
| 30 | #41 | reduction-AND `&a` on 4-bit | PASS (fixed) |
| 31 | #42 | chained `inc u1 (.x(a), .o(mid)); inc u2 (.x(mid), .o(y));` | PASS (fixed) |
| 32 | #43 | `signed (-106) < 127` | PASS (fixed) |
| 33a | #44 | `[W-1:0]` port with default `W=8`, `y = a + 1`, a=255 | PASS (fixed) |
| 33b | #44 | same defect via wider output port | PASS (fixed) |
| 33c | #44 sympt 2 | `localparam K = 3+4` | PASS (regression guard) |
| 34 | #45 | `casez (s) 4'b1???:` arm match | PASS (fixed) |
| 35–36, 38 | — | reductOr / logNot / logAnd 4-bit (regression guards) | PASS |
| 37 | — | bitwise-NOT `~a + 1` on 4-bit (newly discovered) | PASS (fixed) |

## Fixes by file

- **`Tools/SVParser/AST.lean`** — `SVLiteral.binaryWild` for casez
  wildcard literals (#45); `SVPort.widthExpr` for symbolic
  `[W-1:0]` bounds (#44); `SVPort.isSigned` for the `signed`
  keyword (#43).
- **`Tools/SVParser/Lexer.lean`** — `binDigitsOrWildcardStr` and
  the `'b'/'B'` branch in `numericLiteral` (#45); `bitRange`
  now also returns the symbolic `(hiExpr, loExpr)` for
  identifier-bearing bounds (#44, via a new `parseIdentSimple`
  helper and an SVExpr-aware `parseBitRangeVal`).
- **`Tools/SVParser/Parser.lean`** — `parseOptWidthSym` plus the
  port-list loop now thread `widthExpr` and `isSigned` through
  every port (#43, #44).
- **`Tools/SVParser/Lower.lean`**:
  - `mkCaseCond` builds a masked-equality compare for
    `binaryWild` arm labels (#45).
  - `evalConstExpr` learns `.add` / `.sub` / `.mul` so symbolic
    `[W-1:0]` bounds can be resolved (#44).
  - `lowerModule`'s preamble resolves `SVPort.widthExpr`
    against the parameter value map and overwrites the
    parser's `(31, 0)` fallback (#44).
  - `lowerModule`'s preamble also populates a
    `LowerEnv.signedNames` list of `signed` ports (#43).
  - Two new IR post-passes, both *strict refinements*:
    - `narrowMaskConstants` rewrites the 32-bit XOR mask that
      `lowerExpr` emits for `~x` to match the operand's actual
      width (#41 + Test 37).
    - `promoteSignedComparisons` rewrites `.op .lt_u`/`le_u`/
      `gt_u`/`ge_u` to their `_s` counterparts when either
      argument references a `signed` port (#43).
  - `lowerDesign` picks the *non-instantiated* module as the
    top instead of taking source-first (#42).  This matches
    `parseAndLowerHierarchical`'s existing logic.

## Test infrastructure

The reproduction tests use the existing `jitRun` helper
(parse → lower → CppSim → JIT compile → run for N cycles → read
outputs) so failures are observable end-to-end, not only at the
IR level.

`set_option maxRecDepth 1024` is added at the top of
`Tests/SVParser/ParserTest.lean` because the do-block of `main`
now crosses Lean's default 512 limit after the regression additions.

## Test plan

- [x] `lake build svparser-test` — succeeds.
- [x] `lake exe svparser-test` — `40 passed, 0 failed`.
- [x] Each previously failing test (Tests 30, 31, 32, 33a, 33b,
      34, 37) flips FAIL → PASS.
- [x] All pre-existing tests (Tests 1–29) remain PASS — no
      regressions on `next_acc` / `pcpi_mul` / byte-lane /
      replication / for-loop accumulator paths.

Closes #41, #42, #43, #44, #45.