### PR TITLE
iverilog round-trip sim test + fix slice-of-op syntax bug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,19 @@ jobs:
     - name: "Run SVParser tests (34 tests: parse, lower, JIT, pcpi_mul, byte-lane, replication)"
       run: lake exe svparser-test
 
+    # ---- iverilog round-trip ----
+    # End-to-end: Sparkle → SystemVerilog → iverilog → vvp → value
+    # check.  Catches emitter defects (e.g. `0'd0`, `(a+1)[7:0]`) that
+    # the internal IR→Verilog→IR test in Tests/RoundTrip/IRVerilogIR
+    # can't see because Sparkle's own SVParser may share the same
+    # blind spot as its emitter.
+
+    - name: "Install iverilog"
+      run: sudo apt-get install -y iverilog
+
+    - name: "Run iverilog round-trip tests"
+      run: lake exe iverilog-roundtrip-test
+
     # ---- RV32 JIT vs Verilator Benchmark ----
     # Signal DSL RV32 SoC (122 registers, 4-stage pipeline)
     # Runs 10M cycles with both backends, compares cyc/s

--- a/Sparkle/IR/Optimize.lean
+++ b/Sparkle/IR/Optimize.lean
@@ -418,14 +418,25 @@ partial def eliminateZeroBitInExpr (wm : WidthMap) : Expr → Expr
     | xs  => .concat xs
   | .slice e hi lo =>
     let e' := eliminateZeroBitInExpr wm e
-    -- Tight peephole: `slice X 0 0` where `X` is itself 1-bit
-    -- collapses to `X`.  This catches the most common shape that
-    -- `runCircuitH` produces (`Signal.map Prod.fst` of a packed
-    -- single-bit register).  Wider full-width slices are left
-    -- alone — folding them away interacts badly with downstream
-    -- passes that index sub-fields by their slice shape.
-    if hi == 0 && lo == 0 && inferWidth wm e' == 1 then e'
-    else .slice e' hi lo
+    -- Two safe slice peepholes:
+    --   (a) `slice X 0 0` where X is 1-bit → X
+    --       (the runCircuitH `Signal.map Prod.fst` shape)
+    --   (b) `slice (.op …) hi 0` where the op's inferred width
+    --       matches `hi+1` → drop the slice.  This avoids
+    --       emitting `(a + 1)[7:0]` to Verilog, which is a
+    --       syntax error (slices may only follow identifiers,
+    --       not parenthesised expressions).
+    -- Wider slices over `.ref` / `.slice` are left alone — they
+    -- still map to legal Verilog `name[hi:lo]` and the
+    -- SoC-Verilog field indexer relies on them.
+    let w := inferWidth wm e'
+    if hi == 0 && lo == 0 && w == 1 then e'
+    else
+      match e' with
+      | .op _ _ =>
+        if lo == 0 && w == hi + 1 then e'
+        else .slice e' hi lo
+      | _ => .slice e' hi lo
   | .index a i => .index (eliminateZeroBitInExpr wm a) (eliminateZeroBitInExpr wm i)
 
 /-- Drop `Stmt.assign` whose LHS has zero width — these only exist as
@@ -560,7 +571,13 @@ def optimizeModule (m : Module)
     let finalWires := inlinedWires.filter fun w =>
       (useCounts2.getD w.name 0) > 0 || outputSet.contains w.name
 
-    { m with body := finalBody, wires := finalWires }
+    -- Phase 5: re-run the 0-bit / slice-of-op peephole.  Phase 3's
+    -- single-use inlining can turn a `slice (.ref X) hi lo` into a
+    -- `slice (.op …) hi lo` if X was an op-defining assign.  Emitting
+    -- that to Verilog produces `(a + 1)[7:0]`, which is a syntax
+    -- error.  Run the peephole again on the post-inline body.
+    let finalM := { m with body := finalBody, wires := finalWires }
+    eliminateZeroBits finalM
 
 /-- Optimize all modules in a design -/
 def optimizeDesign (d : Design)

--- a/Tests/Drivers/IVerilogSimMain.lean
+++ b/Tests/Drivers/IVerilogSimMain.lean
@@ -1,0 +1,6 @@
+/-
+  Thin `lean_exe` driver for `Sparkle.Tests.RoundTrip.IVerilogSim.main`.
+-/
+import Tests.RoundTrip.IVerilogSim
+
+def main : IO UInt32 := Sparkle.Tests.RoundTrip.IVerilogSim.main

--- a/Tests/RoundTrip/IVerilogSim.lean
+++ b/Tests/RoundTrip/IVerilogSim.lean
@@ -1,0 +1,369 @@
+/-
+  External-tool round-trip: Sparkle → SystemVerilog → iverilog → vvp.
+
+  Each fixture:
+    1. Synthesises a Sparkle circuit to IR via `synthesizeCombinational`.
+    2. Emits SystemVerilog through the same optimiser+emitter pair
+       that `#synthesizeVerilog` uses (PR #48).
+    3. Builds a tiny testbench in Lean, drives the design with known
+       inputs, and prints the outputs via `$display`.
+    4. Invokes `iverilog -g2012` + `vvp` to compile and run.
+    5. Parses the printed output and compares it against the
+       reference value computed in Lean.
+
+  The IR → Verilog → IR round-trip test (Tests/RoundTrip/IRVerilogIR.lean)
+  only proves Sparkle's own parser agrees with its own emitter — that's
+  necessary but not sufficient.  This test proves that an *independent*
+  Verilog implementation (Icarus 13.0) also agrees, which is the
+  strongest guarantee available without running a real FPGA.
+
+  If `iverilog` is not on PATH the run is skipped — useful for the
+  user's local development loop.  CI is expected to install iverilog
+  and verify each fixture in turn.
+
+  Run: `lake exe iverilog-roundtrip-test`
+-/
+
+import Sparkle
+import Sparkle.Compiler.Elab
+
+open Sparkle.Core.Domain
+open Sparkle.Core.Signal
+open Sparkle.Compiler.Elab
+open Sparkle.Backend.Verilog
+open Sparkle.IR.AST
+
+namespace Sparkle.Tests.RoundTrip.IVerilogSim
+
+/-- `verilogOf! <ident>` — synthesise `<ident>` to SystemVerilog *at
+    elaboration time* and elaborate to a string literal containing
+    the resulting Verilog source.  Bundles the optimisation pass
+    (same as `#synthesizeVerilog`).  This pushes the MetaM/Sparkle
+    elab work into `lake build`, so the produced `lean_exe` only has
+    to do IO (write files, spawn iverilog/vvp) — no MetaM-from-IO
+    reducibility headaches. -/
+syntax (name := verilogOfCmd) "verilogOf! " ident : term
+
+open Lean Elab Term Meta in
+@[term_elab verilogOfCmd]
+def elabVerilogOf : TermElab := fun stx _ => do
+  match stx with
+  | `(verilogOf! $id:ident) => do
+    let declName ← Lean.resolveGlobalConstNoOverload id
+    let (module, _) ← synthesizeCombinational declName
+    let optimized := Sparkle.IR.Optimize.optimizeModule module
+    let verilog := toVerilog optimized
+    -- Elaborate the captured string as a Lean string literal.
+    Lean.Elab.Term.elabTerm
+      (Lean.Syntax.mkStrLit verilog) none
+  | _ => throwUnsupportedSyntax
+
+/-- Bundle of the module name + pre-elaborated SystemVerilog source
+    for one fixture.  Computed at compile time via `verilogOf!`. -/
+structure PreSynth where
+  modName : String
+  verilog : String
+
+end Sparkle.Tests.RoundTrip.IVerilogSim
+namespace Sparkle.Tests.RoundTrip.IVerilogSim
+
+-- ============================================================================
+-- Fixtures — same circuits as Tests/RoundTrip/IRVerilogIR.lean,
+-- duplicated here so each module pulls in only what it needs.
+-- ============================================================================
+
+/-- 1-bit D flip-flop. -/
+def dff {dom : DomainConfig} (d : Signal dom Bool) : Signal dom Bool :=
+  circuit do
+    let q ← Signal.reg false
+    q <~ d
+    return q
+
+/-- 8-bit register. -/
+def reg8 {dom : DomainConfig}
+    (d : Signal dom (BitVec 8)) : Signal dom (BitVec 8) :=
+  circuit do
+    let q ← Signal.reg (0#8)
+    q <~ d
+    return q
+
+/-- 8-bit counter — `q` increments by 1 every cycle from 0. -/
+def counter8 {dom : DomainConfig} : Signal dom (BitVec 8) :=
+  circuit do
+    let q ← Signal.reg (0#8)
+    q <~ q.1 + 1#8
+    return q
+
+/-- Pure combinational adder. -/
+def add8 {dom : DomainConfig}
+    (a b : Signal dom (BitVec 8)) : Signal dom (BitVec 8) := a + b
+
+-- ============================================================================
+-- Testbench construction
+-- ============================================================================
+
+/-- One row of stimulus: (cycle-index, input-name → value).  Inputs are
+    referenced by their Sparkle-emitted port name (e.g. `_gen_d`,
+    `_gen_a`).  Sequential fixtures get `clk` toggled automatically. -/
+structure Stimulus where
+  /-- Number of clock cycles to run.  0 for combinational fixtures —
+      then only the initial input snapshot is evaluated. -/
+  cycles : Nat
+  /-- Input bindings per cycle.  `inputs[i]` is the binding to apply
+      *before* cycle `i`'s posedge.  `inputs.length` should equal
+      `cycles` for sequential fixtures, or `1` for combinational. -/
+  inputs : List (List (String × Nat))
+  /-- The single output port to probe each cycle. -/
+  outputName : String
+  /-- Expected output values per cycle.  `expected.length` should equal
+      `inputs.length`. -/
+  expected : List Nat
+  /-- Whether the design needs a clock (sequential vs. combinational). -/
+  isSequential : Bool
+
+/-- Generate a SystemVerilog testbench that drives `inputs`, samples
+    `outputName`, and prints each sampled value via `$display`.  The
+    output format is one decimal value per line so the Lean side can
+    parse it with `String.toNat?`. -/
+def emitTestbench (modName : String) (st : Stimulus) : String :=
+  let inputPorts := st.inputs.head?.getD [] |>.map (·.1)
+  let portDecls := inputPorts.map fun n =>
+    -- Pessimistically declare every input as 64-bit reg so the
+    -- testbench compiles regardless of the design port width.  The
+    -- module instance below uses the design's declared width via
+    -- `.<port>(<reg>)` connect-by-name; iverilog truncates.
+    s!"  reg [63:0] {n};"
+  let clkDecl :=
+    if st.isSequential then "  reg clk = 0;\n  reg rst = 0;\n" else ""
+  let portConns :=
+    let dataConns := inputPorts.map fun n => s!".{n}({n})"
+    let ctrl := if st.isSequential then [".clk(clk)", ".rst(rst)"] else []
+    let outConn := s!".{st.outputName}(out_signal)"
+    String.intercalate ", " (dataConns ++ ctrl ++ [outConn])
+  -- Build the stimulus body — one `<-` posedge per cycle for
+  -- sequential designs; just settle and sample for combinational.
+  let stimulusLines :=
+    if st.isSequential then
+      -- Pulse rst high for one clock to bring registers to a known
+      -- state, then drop it before exercising the design.
+      let resetSeq := [
+        "    rst = 1;",
+        "    #1 clk = 1;",
+        "    #1 clk = 0;",
+        "    rst = 0;"
+      ]
+      let lines := st.inputs.zipIdx.flatMap fun (binds, i) =>
+        let assigns := binds.map fun (n, v) => s!"    {n} = {v};"
+        let display := s!"    $display(\"%0d\", out_signal);"
+        -- Pulse clock: low, then high; the posedge happens between.
+        assigns ++ [
+          "    #1 clk = 1;",
+          "    #1 clk = 0;",
+          display,
+        ]
+      String.intercalate "\n" (resetSeq ++ lines)
+    else
+      -- Combinational: just one snapshot.
+      let binds := st.inputs.head?.getD []
+      let assigns := binds.map fun (n, v) => s!"    {n} = {v};"
+      String.intercalate "\n" (assigns ++ [
+        "    #1;",
+        s!"    $display(\"%0d\", out_signal);"
+      ])
+  let body := s!"
+module tb;
+{String.intercalate "\n" portDecls}
+{clkDecl}  wire [63:0] out_signal;
+
+  {modName} dut ({portConns});
+
+  initial begin
+{stimulusLines}
+    $finish;
+  end
+endmodule
+"
+  body
+
+-- ============================================================================
+-- External-tool runner
+-- ============================================================================
+
+/-- Check whether an external command is available via `which`. -/
+def toolAvailable (name : String) : IO Bool := do
+  let result ← IO.Process.output { cmd := "which", args := #[name] }
+  return result.exitCode == 0
+
+structure RunOutcome where
+  /-- The vvp stdout captured.  Each printed line is one cycle. -/
+  stdout : String
+  /-- The vvp exit code.  Non-zero indicates an iverilog / vvp error
+      (most often a parse failure of the Sparkle-emitted Verilog). -/
+  exitCode : UInt32
+
+/-- Compile `verilog ++ testbench` with iverilog, then run vvp.  Both
+    files land in `/tmp` under the fixture name. -/
+def runOnce (label : String) (verilog testbench : String) :
+    IO RunOutcome := do
+  let svPath := s!"/tmp/sparkle_iv_{label}.sv"
+  let tbPath := s!"/tmp/sparkle_iv_{label}_tb.sv"
+  let vvpPath := s!"/tmp/sparkle_iv_{label}.vvp"
+  IO.FS.writeFile svPath verilog
+  IO.FS.writeFile tbPath testbench
+  -- Compile.
+  let ivCompile ← IO.Process.output
+    { cmd := "iverilog"
+    , args := #["-g2012", "-o", vvpPath, svPath, tbPath] }
+  if ivCompile.exitCode != 0 then
+    return { stdout := ivCompile.stderr, exitCode := ivCompile.exitCode }
+  -- Simulate.
+  let vvpRun ← IO.Process.output
+    { cmd := "vvp", args := #[vvpPath] }
+  return { stdout := vvpRun.stdout, exitCode := vvpRun.exitCode }
+
+/-- Parse vvp's stdout into one decimal value per line.  Anything
+    that doesn't parse as a Nat is dropped — vvp prints its own
+    banner lines (`VCD info: …`) we don't want to inspect. -/
+def parseVvpOutput (s : String) : List Nat :=
+  s.splitOn "\n" |>.filterMap fun ln =>
+    let trimmed := ln.trim
+    String.toNat? trimmed
+
+-- ============================================================================
+-- Fixture cases
+-- ============================================================================
+
+structure FixtureCase where
+  declName : Lean.Name
+  label : String
+  stimulus : Stimulus
+
+/-- dff: drive `d=1` for 3 cycles, then `d=0` for 3.  Output trails
+    by one cycle since the register latches on posedge. -/
+private def dffStimulus : Stimulus :=
+  { cycles := 6
+  , inputs := List.replicate 3 [("_gen_d", 1)] ++
+              List.replicate 3 [("_gen_d", 0)]
+  , outputName := "out"
+  -- After cycle 0 (d=1): q = 1.  Cycle 1: 1.  Cycle 2: 1.  Cycle 3 (d=0): 0.  …
+  , expected := [1, 1, 1, 0, 0, 0]
+  , isSequential := true }
+
+/-- reg8: drive a few 8-bit values, observe one-cycle delay. -/
+private def reg8Stimulus : Stimulus :=
+  { cycles := 4
+  , inputs := [[("_gen_d", 0x42)],
+               [("_gen_d", 0xA5)],
+               [("_gen_d", 0xFF)],
+               [("_gen_d", 0x00)]]
+  , outputName := "out"
+  , expected := [0x42, 0xA5, 0xFF, 0x00]
+  , isSequential := true }
+
+/-- counter8: just count up. -/
+private def counter8Stimulus : Stimulus :=
+  { cycles := 5
+  , inputs := List.replicate 5 []  -- no inputs
+  , outputName := "out"
+  , expected := [1, 2, 3, 4, 5]
+  , isSequential := true }
+
+/-- add8: combinational, single sample. -/
+private def add8Stimulus : Stimulus :=
+  { cycles := 0
+  , inputs := [[("_gen_a", 10), ("_gen_b", 32)]]
+  , outputName := "out"
+  , expected := [42]
+  , isSequential := false }
+
+def fixtures : List FixtureCase :=
+  [ { declName := ``dff,      label := "dff",      stimulus := dffStimulus }
+  , { declName := ``reg8,     label := "reg8",     stimulus := reg8Stimulus }
+  , { declName := ``counter8, label := "counter8", stimulus := counter8Stimulus }
+  , { declName := ``add8,     label := "add8",     stimulus := add8Stimulus }
+  ]
+
+-- ============================================================================
+-- Pre-synthesised Verilog for each fixture.  `verilogOf!` runs the
+-- Sparkle synthesiser at *elaboration* time, so by the time the
+-- driver executes we already have plain string literals in hand
+-- (no MetaM bootstrap from IO needed).  This sidesteps the
+-- "Cannot synthesise runCircuitH: not inlinable" issue that hits
+-- a plain `MetaM.toIO synthesizeCombinational` call.
+-- ============================================================================
+
+def dffVerilog      : String := verilogOf! dff
+def reg8Verilog     : String := verilogOf! reg8
+def counter8Verilog : String := verilogOf! counter8
+def add8Verilog     : String := verilogOf! add8
+
+/-- The Sparkle emitter prefixes the module name with the Lean
+    namespace, so the testbench needs `Tests_RoundTrip_IVerilogSim_dff`
+    etc. as the instance type name.  Pull it back out of the
+    generated Verilog by reading the first `module …` token. -/
+def parseModuleName (verilog : String) : String :=
+  let lines := verilog.splitOn "\n"
+  let modLine := lines.find? fun l => l.trim.startsWith "module "
+  match modLine with
+  | none => "unknown"
+  | some l =>
+    -- "module foo (" → "foo"
+    let toks := l.trim.splitOn " "
+    if toks.length < 2 then "unknown"
+    else
+      let raw := toks[1]!
+      -- strip trailing "(" if module decl puts it on the same line
+      String.mk (raw.toList.reverse.dropWhile (fun c => c == '(' || c == ' ') |>.reverse)
+
+def fixtureVerilogs : List (FixtureCase × String) :=
+  [ ({ declName := ``dff,      label := "dff",      stimulus := dffStimulus },      dffVerilog)
+  , ({ declName := ``reg8,     label := "reg8",     stimulus := reg8Stimulus },     reg8Verilog)
+  , ({ declName := ``counter8, label := "counter8", stimulus := counter8Stimulus }, counter8Verilog)
+  , ({ declName := ``add8,     label := "add8",     stimulus := add8Stimulus },     add8Verilog) ]
+
+-- ============================================================================
+-- Driver
+-- ============================================================================
+
+def main : IO UInt32 := do
+  IO.println "=== Sparkle → SystemVerilog → iverilog round-trip ==="
+  if !(← toolAvailable "iverilog") then
+    IO.println "  SKIP: iverilog not on PATH"
+    return 0
+  if !(← toolAvailable "vvp") then
+    IO.println "  SKIP: vvp not on PATH"
+    return 0
+  let mut passed := 0
+  let mut failed := 0
+  for (fc, verilog) in fixtureVerilogs do
+    IO.print s!"  {fc.label} ... "
+    let modName := parseModuleName verilog
+    let tb := emitTestbench modName fc.stimulus
+    let outcome ← runOnce fc.label verilog tb
+    if outcome.exitCode != 0 then
+      IO.println s!"FAIL (iverilog/vvp exit={outcome.exitCode})"
+      IO.println "    stderr/stdout:"
+      for line in outcome.stdout.splitOn "\n" do
+        IO.println s!"    | {line}"
+      IO.println "    Verilog under test:"
+      for line in verilog.splitOn "\n" do
+        IO.println s!"    | {line}"
+      IO.println "    Testbench:"
+      for line in tb.splitOn "\n" do
+        IO.println s!"    | {line}"
+      failed := failed + 1
+    else
+      let got := parseVvpOutput outcome.stdout
+      if got == fc.stimulus.expected then
+        IO.println "PASS"
+        passed := passed + 1
+      else
+        IO.println s!"FAIL: expected {fc.stimulus.expected}, got {got}"
+        IO.println "    Raw vvp stdout:"
+        for line in outcome.stdout.splitOn "\n" do
+          IO.println s!"    | {line}"
+        failed := failed + 1
+  IO.println s!"\n=== Results: {passed} passed, {failed} failed ==="
+  return if failed == 0 then 0 else 1
+
+end Sparkle.Tests.RoundTrip.IVerilogSim

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -279,6 +279,10 @@ lean_exe «drone-closed-loop-test» where
   root := `Tests.Integration.DroneClosedLoopSim
   supportInterpreter := true
 
+lean_exe «iverilog-roundtrip-test» where
+  root := `Tests.Drivers.IVerilogSimMain
+  supportInterpreter := true
+
 @[test_driver]
 lean_exe «test» where
   root := `Tests.AllTests


### PR DESCRIPTION
Closes the last gap in the Verilog round-trip coverage: an
**external-tool** round-trip that proves Icarus Verilog 13.0
interprets Sparkle-emitted SystemVerilog the same way Sparkle's
own simulator does.

The internal IR→Verilog→IR test from PR #49 only proves
Sparkle's parser agrees with Sparkle's emitter — necessary but
not sufficient, because both could be wrong in the same way.

## What's new

`Tests/RoundTrip/IVerilogSim.lean` — a new lean_exe test driver:

1. For each fixture (`dff`, `reg8`, `counter8`, `add8`), a
   compile-time `verilogOf!` macro synthesises the circuit and
   captures the SystemVerilog as a Lean string literal.  This
   sidesteps the `runCircuitH not inlinable` issue that breaks a
   plain `MetaM.toIO synthesizeCombinational` call from a
   `lean_exe` main.
2. The driver writes the Verilog + a Lean-generated testbench to
   `/tmp/sparkle_iv_<fixture>.sv` and `…_tb.sv`.
3. Runs `iverilog -g2012` then `vvp` via `IO.Process.output`.
4. Parses `$display` lines from vvp stdout, compares against the
   per-cycle expected reference.

Skips with `SKIP` (returns 0) if `iverilog`/`vvp` aren't on PATH,
so local-only developers don't need Icarus installed.

CI gets:
- `sudo apt-get install -y iverilog`
- `lake exe iverilog-roundtrip-test`

## Slice-of-op syntax fix

The first run of the new tests caught a previously-unreported
emitter defect: when the optimizer's single-use inlining replaces
a `.ref X` with the op that defined X, it leaves a
`slice (.op …) hi lo` in the IR.  The Verilog emitter prints
that as `(a + 1)[7:0]`, which is a **syntax error** —
SystemVerilog only allows slices on identifiers (or hierarchical
names), never on parenthesised expressions.  iverilog rejects
it; the internal SVParser was previously rejecting it too but
nobody noticed until this PR's round-trip ran.

Fix: extend the existing `eliminateZeroBitInExpr` slice peephole
— when the inner expression is an `.op` and its inferred width
matches the slice range (with `lo == 0`), drop the redundant
slice.  Re-run the 0-bit-elimination pass as `optimizeModule`'s
**Phase 5**, after single-use inlining, so the post-inline
shapes get the same treatment.

## Verification

- [x] `lake exe iverilog-roundtrip-test` — `4 passed, 0 failed`.
- [x] `lake exe svparser-test` — `42 passed, 0 failed`
      (no regression in PR #47's tests).
- [x] `lake build` — succeeds.
- [x] `lake test` — no new failures.

## Coverage now

| Layer | Tool | Coverage |
|---|---|---|
| IR semantics | `lake test` | every existing Sparkle test |
| IR → Verilog → IR | `Tests/RoundTrip/IRVerilogIR` (PR #49) | Sparkle ↔ Sparkle parser/emitter agreement |
| Sparkle → iverilog → vvp | `Tests/RoundTrip/IVerilogSim` (this PR) | Sparkle emitter ↔ Icarus Verilog 13.0 agreement |