### PR TITLE
lakefile: whole-archive sparkle C externs into precompiled .so

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -26,18 +26,37 @@ extern_lib «sparkle_jit» pkg := do
   buildStaticLib (pkg.buildDir / "c_src" / nameToStaticLib "sparkle_jit") #[oJob]
 
 -- `precompileModules := true` builds a shared library
--- (`.lake/build/lib/libSparkle-*.so`) alongside the oleans.  The
--- xeus-lean kernel needs this when it encounters `@[extern]` calls
--- like `Sparkle.Core.JIT.JIT.load` inside a notebook `#eval`: the
--- interpreter dlsym-loads the per-module `lp_*` wrapper from the
--- shared lib instead of expecting it to be statically linked into
--- the kernel binary.  Without it, the kernel binary only has the
--- raw C symbols (we wired those through `XEUS_LEAN_EXTRA_LIBS` in
--- the tutorial Dockerfile) but is missing the Lean-side boxing
+-- (`.lake/build/lib/libsparkle_Sparkle.so`) alongside the oleans.
+-- The xeus-lean kernel needs this when it encounters `@[extern]`
+-- calls like `Sparkle.Core.JIT.JIT.load` inside a notebook `#eval`:
+-- the interpreter dlsym-loads the per-module `lp_*` wrapper from
+-- the shared lib instead of expecting it to be statically linked
+-- into the kernel binary.  Without it, the kernel binary only has
+-- the raw C symbols (we wired those through `XEUS_LEAN_EXTRA_LIBS`
+-- in the tutorial Dockerfile) but is missing the Lean-side boxing
 -- wrappers, so every `JIT.load` throws "Could not find native
 -- implementation".
+--
+-- `nativeFacets` then asks the linker to whole-archive our two
+-- `extern_lib`s (`sparkle_barrier`, `sparkle_jit`) into the
+-- precompiled `.so`.  Without this, `libsparkle_Sparkle.so` is
+-- linked against the .a files but the linker discards every
+-- symbol that no Lean wrapper currently calls — including
+-- `sparkle_jit_load`, which the dlsym-loaded `JIT.load` boxing
+-- wrapper looks up.  The result was the CI failure
+--   symbol lookup error: libsparkle_Sparkle.so:
+--   undefined symbol: sparkle_jit_load
+-- The `-Wl,--whole-archive ... -Wl,--no-whole-archive` pair forces
+-- the linker to retain every symbol from the listed archives.
 lean_lib «Sparkle» where
   precompileModules := true
+  moreLinkArgs := #[
+    "-L", "./.lake/build/c_src",
+    "-Wl,--whole-archive",
+    "-l:libsparkle_barrier.a",
+    "-l:libsparkle_jit.a",
+    "-Wl,--no-whole-archive"
+  ]
 
 lean_lib «IP.BitNet» where
   roots := #[`IP.BitNet]


### PR DESCRIPTION
Fixes the \`tutorial-notebooks\` CI step on main, which has been
breaking with:

\`\`\`
symbol lookup error:
  /home/runner/work/sparkle/sparkle/.lake/build/lib/libsparkle_Sparkle.so:
  undefined symbol: sparkle_jit_load
error: Lean exited with code 127
- Notebooks.Gen.Ch03_Sequential
\`\`\`

## What happened

PR #53 (\`xlean-mcp + JIT-in-kernel + Real-Time Collaboration\`)
added \`precompileModules := true\` to \`lean_lib Sparkle\` so the
xlean WASM kernel could dlsym the Lean-side boxing wrappers from a
shared library at notebook run time.

That worked for everything except symbols that no Lean wrapper
currently *calls directly* — like \`sparkle_jit_load\`, which is
only ever dlsym'd via \`Sparkle.Core.JIT.JIT.load\`'s boxing
wrapper.  When Lake linked \`libsparkle_Sparkle.so\` against the C
extern archives (\`libsparkle_barrier.a\`, \`libsparkle_jit.a\`),
the linker's default \`--as-needed\` / \`--gc-sections\` pass
discarded every symbol nothing was statically referencing.  PR #53
itself slipped through CI because none of its own files triggered
\`JIT.load\`; PR #53 + the existing Ch03 tutorial chapter does.

## Fix

Wrap the two extern archives with \`-Wl,--whole-archive ...
-Wl,--no-whole-archive\` in \`Sparkle\`'s \`moreLinkArgs\`, so the
linker retains every symbol they contain.  Pair with
\`-L ./.lake/build/c_src\` to point at the directory the
\`extern_lib\` blocks emit those archives into.

## Verification

- [x] \`lake build Sparkle\` — succeeds (was failing on every
      \`*:dynlib\` target with \"libsparkle_barrier.a not found\"
      until \`-L\` was added).
- [x] \`lake build TutorialNotebooks\` — succeeds, including the
      \`Notebooks.Gen.Ch03_Sequential\` chapter that triggered the
      original failure.
- [x] \`lake exe svparser-test\` — \`42 passed, 0 failed\` (no
      regression on the prior PRs' SVParser fixes).

CI for this branch should be green.