### PR TITLE
c_src: export FFI symbols so precompileModules clean builds succeed

### DIFF
--- a/c_src/sparkle_barrier.c
+++ b/c_src/sparkle_barrier.c
@@ -1,5 +1,12 @@
 #include <lean/lean.h>
 
+/* `leanc` compiles with `-fvisibility=hidden`, and `LEAN_EXPORT` only adds
+   default visibility when building libleanshared (LEAN_EXPORTING is set). For
+   an external FFI lib that `precompileModules` loads as a *shared* library at
+   compile time, these @[extern] symbols must be dynamically exported, so force
+   default visibility — an explicit pragma overrides the leanc flag. */
+#pragma GCC visibility push(default)
+
 /*
  * Cache reader for Signal DSL memoization.
  * Reads arr[t] from an IO.Ref, entirely in C to prevent LICM hoisting.
@@ -80,3 +87,5 @@ LEAN_EXPORT lean_obj_res sparkle_eval_at(
     lean_ctor_set(result, 1, lean_io_mk_world());
     return result;
 }
+
+#pragma GCC visibility pop

--- a/c_src/sparkle_jit.c
+++ b/c_src/sparkle_jit.c
@@ -15,6 +15,12 @@
 
 #include <lean/lean.h>
 
+/* `leanc` builds with `-fvisibility=hidden` and `LEAN_EXPORT` is a no-op outside
+   libleanshared, so these @[extern] symbols would be hidden. `precompileModules`
+   loads this as a *shared* library at compile time and must resolve them
+   dynamically — force default visibility (overrides the leanc flag). */
+#pragma GCC visibility push(default)
+
 /* Declare dlopen/dlsym/dlclose/dlerror manually to avoid dlfcn.h
    (Lean's bundled clang uses -nostdinc which excludes system headers) */
 #define RTLD_NOW 2
@@ -475,3 +481,5 @@ LEAN_EXPORT lean_obj_res sparkle_jit_run_cdc(
 
     return mk_io_ok(outer);
 }
+
+#pragma GCC visibility pop


### PR DESCRIPTION
A clean `lake build` deterministically failed: ~12 Signal-dependent modules could not load the precompiled Signal.so (`undefined symbol: sparkle_cache_get`). Only stale incremental .lake state hid it.

Root cause: with `precompileModules := true`, lean loads the FFI as *shared* libraries at compile time and resolves @[extern] symbols dynamically. But those symbols were hidden -- leanc force-appends -fvisibility=hidden, and LEAN_EXPORT is a no-op outside libleanshared (it only adds visibility("default") when LEAN_EXPORTING is set). So libsparkle_barrier.so / libsparkle_jit.so exported nothing. Static-link builds were unaffected (link-time resolution), which is why incremental builds masked the bug.

Fix: force default visibility on the FFI functions via `#pragma GCC visibility push(default)` / `pop` in sparkle_barrier.c and sparkle_jit.c (an explicit pragma overrides the leanc flag). WASM-safe (sparkle_jit.c is swapped for the stub under emscripten) and harmless for the static-link path.