### PR TITLE
ci(pages): drop leading dot from Sparkle xlean kernel prefix path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -853,7 +853,17 @@ jobs:
                && [ -f /opt/xeus-lean/CMakeLists.txt ] \
                && [ -d "$STOCK_PREFIX/conda-meta" ]; then
               echo "::group::Sparkle WASM staging + xlean rebuild"
-              CAND=/work/.sparkle-kernel-prefix
+              # NOTE: NO leading dot.  jupyterlite-xeus uses the basename of
+              # `--XeusAddon.prefix` as the env_name inside the deployed site
+              # (`site/xeus/<env_name>/<kernel>/kernel.json`).  When that
+              # basename starts with `.`, the directory is hidden and the
+              # actions/deploy-pages upload (Jekyll-style filtering of dotfiles)
+              # drops the entire `site/xeus/.sparkle-kernel-prefix/` tree —
+              # leaving `xeus/kernels.json` listing an env whose kernel.json
+              # 404s in the browser.  See run 27898159343 logs:
+              #   jupyterlite-xeus:xeus:.sparkle-kernel-prefix:update_env_file:...
+              # then `https://verilean.github.io/sparkle/xeus/kernels.json` → `[]`.
+              CAND=/work/sparkle-kernel-prefix
               if pixi run --manifest-path /opt/xeus-lean/pixi.toml -e wasm-build \
                    bash /work/tools/wasm/build-wasm.sh /work/.sparkle-staging \
                  && cp -a "$STOCK_PREFIX" "$CAND" \


### PR DESCRIPTION
## What

`/work/.sparkle-kernel-prefix` → `/work/sparkle-kernel-prefix`
(1 char dot removed; 10 lines of explanatory comment added).

## Why

Today `verilean.github.io/sparkle/lab/index.html` loads the JupyterLite
SPA but the Lean 4 kernel card never appears in the Launcher — only
"Text File / Markdown File / Show Contextual Help" are visible.

Root cause:

* `jupyter lite build --XeusAddon.prefix=/work/.sparkle-kernel-prefix`
  uses the basename of the prefix (`.sparkle-kernel-prefix`) as the
  conda-style `env_name` inside the generated site.
* It writes `site/xeus/kernels.json` listing that env name and stages
  the kernel under `site/xeus/.sparkle-kernel-prefix/xlean/kernel.json`.
* `actions/deploy-pages` then Jekyll-filters dotfiles, which drops the
  entire `site/xeus/.sparkle-kernel-prefix/` tree from the upload.
* On the live site, `kernels.json` ends up as `[]` and the kernel
  cards never render.

Compare:

| | xeus-lean Pages (works) | sparkle Pages (broken) |
|---|---|---|
| `/xeus/kernels.json` | `[{"kernel":"xlean","env_name":"wasm-host"}]` | `[]` |
| Launcher | Lean 4 card visible | Lean 4 card missing |

Dropping the leading dot keeps the path off Jekyll's exclusion list
and gives jupyterlite-xeus a valid env name to ship.

## How verified

Diagnosed via the [lean-tea](https://github.com/Verilean/lean-tea)
browser MCP driver + Playwright/Chromium, fetching the deployed
`/xeus/kernels.json` from both sites for comparison.

After this PR merges and Pages redeploys, the Launcher should show
the Lean 4 kernel card again.