### PR TITLE
docs(readme): hosted site links + Verilator/xeus-lean/iverilog/Yosys ack

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,23 @@
 A type-safe hardware description language that brings dependent types and
 theorem proving to hardware design.
 
+**Live docs & benchmarks:** the project publishes three hosted pages at
+[verilean.github.io/sparkle](https://verilean.github.io/sparkle/):
+
+- 📘 [**Tutorial (JupyterLite)**](https://verilean.github.io/sparkle/tutorial/) —
+  the multi-chapter beginner course, runnable in-browser via xeus-lean.
+  *(Known issue: some environments fail to boot the Lean kernel or load Sparkle;
+  when that happens, read the rendered notebooks under
+  [`docs/tutorial/Notebooks/`](docs/tutorial/Notebooks/) or use the
+  Docker path in [Quick Start](#quick-start) below.)*
+- 🔎 [**API reference (doc-gen4)**](https://verilean.github.io/sparkle/api/) —
+  fully cross-linked documentation for every public definition, generated
+  from the source with `lake build Sparkle:docs`.
+- 📈 **Benchmarks** — CI-driven history of the RV32 JIT vs Verilator numbers:
+  [RV32 SoC](https://verilean.github.io/sparkle/dev/rv32-bench/) ·
+  [LiteX PicoRV32](https://verilean.github.io/sparkle/dev/litex-bench/) ·
+  [Multi-core (8-thread)](https://verilean.github.io/sparkle/dev/multicore-bench/)
+
 **Quick Start:** the multi-chapter [tutorial](docs/tutorial/) walks
 from "hello counter" through Verilog generation, proofs, and FPGA
 bring-up.  Run it in Docker, in your browser via xeus-lean's
@@ -267,7 +284,18 @@ Each IP has a dedicated getting-started recipe in its own doc
 
 ## Documentation
 
-Generate the full API reference locally with doc-gen4:
+- **Hosted (built by CI, always up-to-date with `main`):**
+  - 📘 [Tutorial (JupyterLite)](https://verilean.github.io/sparkle/tutorial/) —
+    in-browser, xeus-lean kernel.  *(Boot issues on some machines — see
+    "Live docs & benchmarks" at the top of this README for the fallback.)*
+  - 🔎 [API reference](https://verilean.github.io/sparkle/api/) —
+    doc-gen4 site covering every public definition.
+  - 📈 Benchmarks —
+    [RV32 SoC](https://verilean.github.io/sparkle/dev/rv32-bench/),
+    [LiteX PicoRV32](https://verilean.github.io/sparkle/dev/litex-bench/),
+    [Multi-core 8-thread](https://verilean.github.io/sparkle/dev/multicore-bench/).
+- **Generate the API reference locally with doc-gen4:**
+
 
 ```bash
 lake -R -Kenv=dev build Sparkle:docs
@@ -483,6 +511,17 @@ Apache License 2.0 — see [LICENSE](LICENSE).
 
 - Inspired by [Clash HDL](https://clash-lang.org/)
 - Built with [Lean 4](https://lean-lang.org/)
+- Golden-reference cycle-accurate simulation via
+  [Verilator](https://www.veripool.org/verilator/) — used both
+  as the CI co-sim reference and as the "if the JIT disagrees,
+  the JIT is wrong" arbiter throughout the test suite.
+- In-browser Lean via [xeus-lean](https://github.com/xeus/xeus-lean)
+  and [JupyterLite](https://jupyterlite.readthedocs.io/) —
+  powers the hosted tutorial notebooks.
+- Verilog toolchain integration via
+  [iverilog](https://steveicarus.github.io/iverilog/) (round-trip
+  checks) and [Yosys](https://yosyshq.net/yosys/) (used in
+  Ch 8 of the tutorial for equivalence checking / FPGA fit).
 
 ## Community
 


### PR DESCRIPTION
## Summary

- **README top: \"Live docs & benchmarks\" block** — advertise
  the three hosted pages at
  [verilean.github.io/sparkle](https://verilean.github.io/sparkle/):
  Tutorial (JupyterLite), API reference (doc-gen4), and the
  three CI-driven benchmark pages (RV32 SoC, LiteX PicoRV32,
  Multi-core 8-thread).  Also flag the current JupyterLite
  boot issue (kernel / Sparkle load failure on some machines)
  with a pointer to the rendered notebooks under
  \`docs/tutorial/Notebooks/\` as the fallback.
- **README \"Documentation\" section** — add the same hosted
  URLs so anyone jumping straight to the doc pointers list
  also sees them.
- **README Acknowledgments** — credit the third-party projects
  Sparkle materially depends on but that weren't listed:
  - **Verilator** — the co-sim golden reference and \"if JIT
    disagrees, JIT is wrong\" arbiter used throughout the CI
    test suite.
  - **xeus-lean + JupyterLite** — powers the hosted tutorial.
  - **iverilog** (round-trip fixture checks) and **Yosys**
    (equivalence + FPGA fit walkthrough in the Ch 8 tutorial).

No code changes — all in README.md.

## Test plan

- [x] Every added link verified with \`curl -sSL -o /dev/null
      -w '%{http_code}' <url>\` → 200 for all six hosted URLs
      (base + tutorial + api + 3× dev bench).
- [x] \`grep -c 'verilean.github.io'\` = 11 (badge + block + doc
      section + benchmarks × 3, present in both top and docs
      sections).
- [x] No stray CI or lakefile changes — pure docs update.
