### PR TITLE
LoopProps: make loop_unfold a theorem, not an axiom (pure loopGo fixpoint)

### DIFF
--- a/Sparkle/Core/Signal.lean
+++ b/Sparkle/Core/Signal.lean
@@ -807,8 +807,50 @@ where
       | .ok v => v
       | .error _ => default⟩
 
+/-- The pure fixpoint value of a feedback loop, computed by strong
+    recursion on the time index.
+
+    To compute the value at time `t`, we apply the loop body `f` to a
+    signal that recursively supplies the already-computed values for
+    every earlier cycle `i < t` and `default` at `t` and beyond.  For a
+    *strictly causal* `f` (every feedback path runs through a
+    `Signal.register`, so the output at `t` reads only inputs strictly
+    before `t`), the `default` placeholder at `≥ t` is never observed,
+    so this is exactly the loop's fixpoint — see `loop_unfold` in
+    `Sparkle/Verification/LoopProps.lean`, now a *theorem* rather than
+    an axiom.
+
+    The `if i < t` guard makes the recursion well-founded (`t`
+    strictly decreases), so this is a total, axiom-free definition.
+
+    Runtime note: this naive form recomputes the `< t` prefix on every
+    cycle (O(t) work per cycle → O(n²) for an n-cycle sim).  The
+    `@[implemented_by loopImpl]` on `loop` below swaps in the
+    memoizing `loopImpl` for *execution*, keeping O(n); the pure
+    `loopGo`/`loop` definitions are what the kernel and the proofs
+    see. -/
+def loopGo {dom : DomainConfig} {α : Type} [Inhabited α]
+    (f : Signal dom α → Signal dom α) (t : Nat) : α :=
+  (f ⟨fun i => if i < t then loopGo f i else default⟩).val t
+termination_by t
+
+/-- Fixed-point combinator for feedback loops.
+
+    Logically this is the pure `loopGo` fixpoint (no axiom, no
+    `opaque`, no `unsafe`).  For *execution* it is compiled to the
+    memoizing `loopImpl` via `@[implemented_by]`, which keeps
+    cycle-by-cycle simulation at O(n) instead of the O(n²) the naive
+    `loopGo` would cost. -/
 @[implemented_by loopImpl]
-opaque loop {dom : DomainConfig} {α : Type} [Inhabited α] (f : Signal dom α → Signal dom α) : Signal dom α
+def loop {dom : DomainConfig} {α : Type} [Inhabited α]
+    (f : Signal dom α → Signal dom α) : Signal dom α :=
+  ⟨loopGo f⟩
+
+/-- `loopGo`'s defining equation, exposed for proofs. -/
+theorem loopGo_eq {dom : DomainConfig} {α : Type} [Inhabited α]
+    (f : Signal dom α → Signal dom α) (t : Nat) :
+    loopGo f t = (f ⟨fun i => if i < t then loopGo f i else default⟩).val t := by
+  rw [loopGo]
 
 /-- Memoize an existing Signal so each `.val t` is computed
     at most once.  Same C-FFI cache trick as `loop`, but for

--- a/Sparkle/Verification/LoopProps.lean
+++ b/Sparkle/Verification/LoopProps.lean
@@ -1,24 +1,30 @@
 /-
   Signal.loop Characterization — closing the gap for feedback-circuit proofs.
 
-  `Signal.loop` is declared `opaque` (its real implementation is an `unsafe`
-  IO memoization that breaks combinational cycles), so `(Signal.loop f).val t`
-  cannot be unfolded by the kernel.  That is why feedback circuits were listed
-  as a *non-goal* in `Equivalence.lean`: nothing connected the opaque loop to a
-  value we can compute with.
+  `Signal.loop` is now a *pure* definition (`⟨loopGo f⟩`, the strong-
+  recursion fixpoint on the time index — see `Sparkle/Core/Signal.lean`),
+  not an `opaque` wrapper.  Its execution is still the fast memoizing
+  `loopImpl` via `@[implemented_by]`, but its *logical* value is the pure
+  fixpoint, so `(Signal.loop f).val t` unfolds in the kernel.
 
-  This file supplies the missing connection.  The single trusted assumption is
-  the fixpoint equation `loop f = f (loop f)`, valid ONLY for *strictly causal*
-  `f` — every feedback path passes through a register, so the output at time `t`
-  depends only on inputs strictly before `t`.
+  This file supplies the reduction from that fixpoint to a pure state
+  iterate.  The key fact is the fixpoint equation `loop f = f (loop f)`,
+  which holds for *strictly causal* `f` — every feedback path passes
+  through a register, so the output at time `t` depends only on inputs
+  strictly before `t`.
 
-  Soundness.  An unrestricted `∀ f, loop f = f (loop f)` is FALSE: take
-  `f s = ~~~s` (pointwise Bool negation); it has no fixpoint, and the equation
-  would give `b = !b`, hence `False`.  Restricting to `StrictlyCausal f` is
-  sound: such an endofunction on `Nat → α` has a *unique* fixpoint, definable by
-  well-founded recursion on the time index, so a model interpreting the opaque
-  `loop` as that fixpoint exists.  The unsafe memoizing implementation computes
-  exactly this fixpoint; the axiom is the formal stand-in for it.
+  `loop_unfold` used to be a trusted *axiom*; it is now a *theorem*
+  (proved from `loopGo`'s defining equation + `StrictlyCausal`).  The
+  only remaining trust base for this file is Lean's own `Quot.sound`
+  (used by `funext`), which every Lean development already relies on.
+
+  Why `StrictlyCausal` is needed.  An unrestricted `∀ f, loop f =
+  f (loop f)` is FALSE: take `f s = ~~~s` (pointwise Bool negation); it
+  has no fixpoint, and the equation would give `b = !b`, hence `False`.
+  `loopGo` sidesteps this by feeding `f` a signal that is `default` at
+  cycles `≥ t`; for a strictly causal `f` those placeholder cycles are
+  never observed, so `loopGo` computes the genuine fixpoint and
+  `loop_unfold` goes through.
 -/
 import Sparkle.Core.Signal
 
@@ -111,11 +117,31 @@ def StrictlyCausal (f : Signal dom α → Signal dom α) : Prop :=
   ∀ (s₁ s₂ : Signal dom α) (t : Nat),
     (∀ i, i < t → s₁.val i = s₂.val i) → (f s₁).val t = (f s₂).val t
 
-/-- THE trusted axiom.  For a strictly causal endofunction, `Signal.loop`
-    satisfies the fixpoint equation.  Sound because a strictly causal `f` has a
-    unique fixpoint; see the file header. -/
-axiom loop_unfold [Inhabited α] (f : Signal dom α → Signal dom α)
-    (hf : StrictlyCausal f) : Signal.loop f = f (Signal.loop f)
+/-- The fixpoint equation for `Signal.loop`.
+
+    Previously a trusted *axiom*; now a *theorem*, because `Signal.loop`
+    is defined as the pure strong-recursion fixpoint `⟨loopGo f⟩` (see
+    `Sparkle/Core/Signal.lean`) rather than an `opaque` wrapper around
+    the memoizing implementation.  The proof rewrites through
+    `loopGo`'s defining equation and uses `StrictlyCausal` to discharge
+    the `default` placeholder that `loopGo` supplies at cycles `≥ t`
+    (those cycles are never observed by a strictly causal body).
+
+    (`Signal.loop` still *executes* via the memoizing `loopImpl` through
+    `@[implemented_by]`; that only affects compiled code, not this
+    kernel-level equation.) -/
+theorem loop_unfold [Inhabited α] (f : Signal dom α → Signal dom α)
+    (hf : StrictlyCausal f) : Signal.loop f = f (Signal.loop f) := by
+  have hval : ∀ t, Signal.loopGo f t = (f (Signal.loop f)).val t := by
+    intro t
+    rw [Signal.loopGo_eq]
+    apply hf
+    intro i hi
+    show (if i < t then Signal.loopGo f i else default) = Signal.loopGo f i
+    rw [if_pos hi]
+  show (⟨Signal.loopGo f⟩ : Signal dom α) = f (Signal.loop f)
+  have : Signal.loopGo f = (f (Signal.loop f)).val := funext hval
+  rw [this]
 
 -- ============================================================================
 -- Master reduction: a Signal.loop of registers ≡ a pure state iterate

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -48,7 +48,7 @@ extern_lib «sparkle_jit» pkg := do
 --   ls .lake/build/lib/lean/sparkle_Sparkle*.so
 -- A missing entry shows up as an undefined-symbol load error naming the module.
 def sparkleModuleDeps : Array String := #[
-    "-l:sparkle_Sparkle_Backend_CppSim.so",
+    "-l:sparkle_Sparkle_Backend_CSim.so",
     "-l:sparkle_Sparkle_Backend_VCD.so",
     "-l:sparkle_Sparkle_Backend_Verilog.so",
     "-l:sparkle_Sparkle_Compiler_DRC.so",
@@ -65,6 +65,7 @@ def sparkleModuleDeps : Array String := #[
     "-l:sparkle_Sparkle_Core_Oracle.so",
     "-l:sparkle_Sparkle_Core_OracleSpec.so",
     "-l:sparkle_Sparkle_Core_Signal.so",
+    "-l:sparkle_Sparkle_Core_SignalLeavesDerive.so",
     "-l:sparkle_Sparkle_Core_SimParallel.so",
     "-l:sparkle_Sparkle_Core_SimPureLean.so",
     "-l:sparkle_Sparkle_Core_Sim.so",

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -149,20 +149,36 @@ def sparkleDynlibLinkArgs : Array String :=
 -- against Sparkle's own package dir during `lake build` here; a
 -- separate downstream consumer that precompiles Sparkle may need an
 -- absolute path (see commit 67d2c73 for that history).
+-- Absolute path to this package's build dir, captured at lakefile
+-- elaboration.  `decide`-free: `__dir__` is the directory containing
+-- *this* lakefile, so `<pkgdir>/.lake/build/c_src` is correct whether
+-- Sparkle is the root package (`lake build` here) OR a git dependency
+-- of a downstream project (`<downstream>/.lake/packages/sparkle/…`).
+-- Using this instead of a relative `./.lake/build/c_src` is what keeps
+-- the barrier/jit force_load args from breaking downstream consumers,
+-- whose CWD-relative `./.lake/build/c_src` is their own empty build dir.
+def sparkleCSrcDir : System.FilePath :=
+  (__dir__ : System.FilePath) / ".lake" / "build" / "c_src"
+
 lean_lib «Sparkle» where
   precompileModules := true
+  -- Force the two extern archives whole-into the precompiled
+  -- `libsparkle_Sparkle.so` so it self-resolves `sparkle_cache_get` /
+  -- `sparkle_eval_at` (the `@[extern]` LICM barriers `Signal.loop`'s
+  -- memoization uses) regardless of dlopen load order.  Without this the
+  -- interpreter/LSP fails to load the `.so` with an undefined-symbol
+  -- error.  The path is ABSOLUTE (`sparkleCSrcDir`) so a downstream
+  -- consumer that inherits these args still finds Sparkle's own populated
+  -- c_src — the relative form (PR #65 `c59820c`) broke downstream-smoke.
   moreLinkArgs :=
+    let barrier := (sparkleCSrcDir / "libsparkle_barrier.a").toString
+    let jit := (sparkleCSrcDir / "libsparkle_jit.a").toString
     if System.Platform.isOSX then
-      #["-Wl,-force_load,.lake/build/c_src/libsparkle_barrier.a",
-        "-Wl,-force_load,.lake/build/c_src/libsparkle_jit.a"]
+      #[s!"-Wl,-force_load,{barrier}", s!"-Wl,-force_load,{jit}"]
     else if System.Platform.isWindows then
       #[]
     else
-      #["-L", "./.lake/build/c_src",
-        "-Wl,--whole-archive",
-        "-l:libsparkle_barrier.a",
-        "-l:libsparkle_jit.a",
-        "-Wl,--no-whole-archive"]
+      #["-Wl,--whole-archive", barrier, jit, "-Wl,--no-whole-archive"]
 
 lean_lib «IP.BitNet» where
   roots := #[`IP.BitNet]


### PR DESCRIPTION
## Summary

Removes the custom `loop_unfold` **axiom** introduced in PR #65,
replacing it with a proved **theorem**.  `Signal.loop` is now a pure
definition (`⟨loopGo f⟩`, the strong-recursion fixpoint) instead of an
`opaque` wrapper around the `unsafe` memoizing `loopImpl`.  Execution
stays fast via `@[implemented_by loopImpl]`; only the *logical* value
changes from "unknowable opaque" to "the pure fixpoint the kernel can
unfold".

Prompted by the review question on PR #65: *"loop is a Lean
expression, so why does it need an axiom?"* — the answer was "because
it was `opaque`", and this PR removes that `opaque`.

## What changed

**`Sparkle/Core/Signal.lean`**
- `loopGo f t` — fixpoint value at time `t` by strong recursion on `t`:
  apply `f` to a signal supplying the already-computed values for
  `i < t` and `default` at `≥ t`.  `if i < t` guard ⇒ well-founded
  (`termination_by t`).  Total, no axiom, no `unsafe`.
- `loop f := ⟨loopGo f⟩` — a `def`, not `opaque`, still
  `@[implemented_by loopImpl]` for O(n) execution.
- `loopGo_eq` — defining equation exposed for proofs.

**`Sparkle/Verification/LoopProps.lean`**
- `loop_unfold` : `axiom` → `theorem`, proved from `loopGo_eq` +
  `StrictlyCausal` (a strictly causal body never observes the
  `default` placeholder at cycles `≥ t`).
- Docstring rewritten.

## Trust base (the point of the PR)

`#print axioms dividerSignal_result_gen` (downstream RV32 divider
theorem from PR #65) **no longer lists `loop_unfold`**.  Remaining
axioms are all Lean-standard:

```
propext, Classical.choice, Quot.sound,     -- Lean core
Lean.ofReduceBool,                          -- bv_decide/native_decide (pre-existing)
Lean.trustCompiler                          -- @[implemented_by] (standard)
```

The bespoke fixpoint axiom is gone.  The only loop-specific trust is
now `Lean.trustCompiler` (that `loopImpl` computes the same value as
`loopGo`), which is the same compiler-trust every `@[implemented_by]`
in the codebase already relies on — a much weaker and more standard
assumption than a hand-written fixpoint axiom.

## Performance

`@[implemented_by loopImpl]` keeps simulation at O(n):
- direct `Signal.loop` counter: `.val 2000` in ~0 ms (probe).
- matched `lake exe test`: main **7m52s** vs this branch **8m02s** —
  within noise, no regression.

## Also fixed (latent `main` bugs surfaced by the first clean build)

`lakefile.lean`'s `sparkleModuleDeps` monolithic-link list was stale;
a from-scratch `.lake/build` wipe exposed two missing/renamed `.so`:
- `sparkle_Sparkle_Backend_CppSim.so` → `_CSim.so` (CppSim was
  replaced by the C-only CSim backend; the old `.so` no longer exists).
- added `sparkle_Sparkle_Core_SignalLeavesDerive.so` (the
  `SignalLeaves` deriving handler from the per-leaf output-port split
  was never registered).

Both only bite a clean build — incremental builds kept the stale `.so`
around, which is why CI hadn't caught them.

## Verification

- `lake build` clean.
- `lake exe test`: 13/13 lspec pass.
- Both `Sparkle.Verification.Divider.{Correct,States33}` build against
  the new pure `loop` **with zero proof changes** — PR #65's divider
  proof is now the regression test confirming `loopGo` is the correct
  fixpoint.

