### PR TITLE
docs: document glibc >= 2.34 prerequisite (fixes #28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,20 @@ both out of the box:
 
 ## Quick Start
 
+**Prerequisites:** a **glibc ≥ 2.34** Linux (Ubuntu 22.04+,
+Debian 12+, Fedora 35+), macOS, or WSL2.  Older systems
+(e.g. Ubuntu 20.04, glibc 2.31) fail during `lake build` with
+
+```
+.../bin/cadical: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found
+```
+
+— `cadical` is the SAT solver bundled with the Lean 4.28
+toolchain (used by `bv_decide` / `omega`), and it is linked
+against glibc 2.34.  This is a Lean-toolchain requirement, not a
+Sparkle one; upgrade the OS (or use the Docker path in the
+tutorial) if you hit it.
+
 ```bash
 git clone https://github.com/Verilean/sparkle.git
 cd sparkle

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -21,6 +21,13 @@ A step-by-step guide from "Hello World" to formal verification.
 
 ## Prerequisites
 
+A **glibc ≥ 2.34** Linux (Ubuntu 22.04+, Debian 12+, Fedora 35+),
+macOS, or WSL2.  On older systems (Ubuntu 20.04 / glibc 2.31)
+`lake build` aborts with `cadical: … version 'GLIBC_2.34' not
+found` — `cadical` (the SAT solver in the Lean 4.28 toolchain,
+used by `bv_decide` / `omega`) needs glibc 2.34.  It's a
+Lean-toolchain requirement; upgrade the OS or use Docker.
+
 ```bash
 git clone https://github.com/Verilean/sparkle
 cd sparkle


### PR DESCRIPTION
Closes #28.

`lake build` on Ubuntu 20.04 (glibc 2.31) aborts with:

    .../bin/cadical: /lib/x86_64-linux-gnu/libc.so.6:
      version `GLIBC_2.34' not found (required by .../cadical)

`cadical` is the SAT solver bundled with the **Lean 4.28
toolchain** (used by `bv_decide` / `omega`), linked against
glibc 2.34 — so anything older can't load it.  This is a
Lean-toolchain requirement, **not a Sparkle bug** (nothing in
Sparkle's own code can change it).

But the README Quick Start and `docs/Tutorial.md` Prerequisites
listed no minimum OS/glibc, so a 20.04 user hit the error with
zero guidance.  This adds a prerequisite note to both:

- **glibc ≥ 2.34** → Ubuntu 22.04+ / Debian 12+ / Fedora 35+ /
  macOS / WSL2, or use the Docker path.
- Reproduces the exact error string so it's greppable by the
  next person who searches for it.

No code change — docs only.