### PR TITLE
ci(pages): fix JupyterLite "No Kernel" — absolute argv[0] in xlean kernel.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -934,6 +934,34 @@ jobs:
                       cmake --install /work/.wasm-rebuild \
                  && [ -f "$CAND/conda-meta/history" ]
               then
+                # FIX (issue #85): the rebuild installs xeus-lean'\''s
+                # SOURCE kernel.json, whose `argv[0]` is the bare
+                # relative string "xlean".  jupyterlite-xeus'\''s
+                # `get_kernel_binaries` (add_on.py) then looks for
+                # "xlean.js" / "xlean.wasm" relative to `jupyter lite
+                # build`'\''s cwd (/work) — which don'\''t exist there —
+                # warns "kernel binaries not found for xlean", drops
+                # the kernel from the manifest, and the deployed
+                # `xeus/kernels.json` comes out `[]` → the lab shows
+                # "No Kernel".  The actual binaries are at
+                # `$CAND/bin/xlean.{js,wasm}`, so rewrite argv[0] to
+                # that absolute path.  (The stock image env'\''s
+                # kernel.json already uses an absolute
+                # `/opt/.../bin/xlean`; `cmake --install` clobbered it
+                # with the relative source template.)
+                KJSON="$CAND/share/jupyter/kernels/xlean/kernel.json"
+                if [ -f "$KJSON" ] && [ -f "$CAND/bin/xlean.js" ]; then
+                  # The rebuild installs xeus-lean'\''s SOURCE
+                  # kernel.json, whose argv is the bare relative
+                  # string "xlean" on its own line.  Rewrite that one
+                  # line to the absolute install path so
+                  # jupyterlite-xeus'\''s get_kernel_binaries resolves
+                  # xlean.js / xlean.wasm (no jq in the image; sed on
+                  # the standalone "xlean" argv line is quote-safe).
+                  sed -i "s|^\( *\)\"xlean\"\( *\)$|\1\"$CAND/bin/xlean\"\2|" "$KJSON"
+                  echo "  rewrote $KJSON argv[0] -> $CAND/bin/xlean"
+                  grep -A1 '"argv"' "$KJSON" || true
+                fi
                 SPARKLE_PREFIX="$CAND"
                 echo "Sparkle-enabled kernel installed at $SPARKLE_PREFIX"
               else


### PR DESCRIPTION
## Problem

The hosted lab https://verilean.github.io/sparkle/lab/ shows **"No Kernel"** — no Lean 4 kernel is offered. The deployed `xeus/kernels.json` is `[]`.

Closes #85.

## Root cause

The WASM kernel rebuild step runs `cmake --install` into the staging prefix, which installs xeus-lean's **source** `kernel.json`. That template's argv is the bare relative string:

```json
"argv": [ "xlean" ]
```

(The stock env kernel.json uses an absolute `/opt/.../bin/xlean`, but `cmake --install` clobbers it.)

`jupyter lite build` → `jupyterlite_xeus.add_on.get_kernel_binaries` reads `argv[0]` and checks `argv[0] + ".js"` / `+ ".wasm"`. With `argv[0] == "xlean"` those resolve relative to the build cwd (`/work`), where the binaries do **not** exist — the real ones are at `$CAND/bin/xlean.{js,wasm}`. So it warns "kernel binaries not found for xlean", drops the kernel, and `kernels.json` comes out `[]`.

## Fix

After `cmake --install`, rewrite the installed kernel.json's sole argv line from the relative `"xlean"` to the absolute `$CAND/bin/xlean`. Uses `sed` on the standalone argv line — the docs-builder image has no `jq`, and `sed` avoids the nested-heredoc quoting hazard inside the docker `bash -c '…'`.

## Verification

Confirmed inside the docs-builder image that after the rewrite `get_kernel_binaries` resolves both `xlean.js` and `xlean.wasm` (**FOUND**, vs NOT FOUND before) — which is what populates `xeus/kernels.json` and lets the lab offer the Lean 4 kernel.