### PR TITLE
fix(wasm): embed Sparkle oleans into the hosted-lab kernel (import Sparkle → unknown namespace)

### DIFF
--- a/tools/wasm/build-wasm.sh
+++ b/tools/wasm/build-wasm.sh
@@ -210,29 +210,56 @@ emcc -O2 -sMEMORY64 -fPIC -w \
      -o "$OBJ_JIT_STUB"
 
 # 2c. Lake-generated `.c` wrappers for every `@[extern]` declaration.
-# These live under `.lake/build/ir/<module-path>.c`.  We find every
-# .c there and compile it with the LEAN_MIMALLOC override.
+# These live under `.lake/build/ir/<module-path>.c`.
+#
+# We MUST compile every module the umbrella `Sparkle.olean` transitively
+# imports — not just the `ir/Sparkle/` subtree.  `Sparkle` re-exports
+# `IP.*`, `Tools.*`, etc., and their generated wrappers reference each
+# other's `initialize_sparkle_<Module>` init functions.  Archiving only
+# `ir/Sparkle/` left the umbrella's `initialize_sparkle_Sparkle` and the
+# `IP.*` inits (e.g. `initialize_sparkle_IP_RV32_Divider`) UNDEFINED, so
+# `wasm-ld --whole-archive libsparkle_wasm.a` failed and the whole
+# Sparkle-enabled kernel rebuild silently fell back — which is why the
+# deployed lab had the Sparkle *symbols* but NOT the `.olean` files, and
+# `import Sparkle.Core.Domain` reported "unknown namespace".
+#
+# So: compile ALL of `ir/**/*.c` EXCEPT the executable entry point
+# (`Main.c`) and the test tree (`ir/Tests/`), which the library must not
+# pull in.  ~500 files, so compile in parallel.
 IR_ROOT="$REPO_ROOT/.lake/build/ir"
 declare -a WRAPPER_OBJS=()
 WRAPPER_COUNT=0
-if [ -d "$IR_ROOT/Sparkle" ]; then
-    while IFS= read -r -d '' src; do
-        rel="${src#$IR_ROOT/}"
-        # Strip ".c" → "obj name".  Underscore-escape the slashes so
-        # we keep a flat staging/lib/.
-        obj_name="$(echo "${rel%.c}" | tr '/' '_').o"
-        obj="$STAGING/lib/$obj_name"
-        emcc -O2 -sMEMORY64 -fPIC -w \
-             -I"$LEAN_INCLUDE" \
-             -include lean/config.h \
-             -include "$OVERRIDE_H" \
-             -c "$src" \
-             -o "$obj"
-        WRAPPER_OBJS+=("$obj")
-        WRAPPER_COUNT=$((WRAPPER_COUNT + 1))
-    done < <(find "$IR_ROOT/Sparkle" -name '*.c' -print0)
+JOBS="$(nproc 2>/dev/null || echo 4)"
+compile_wrapper() {
+    local src="$1"
+    local rel="${src#"$IR_ROOT"/}"
+    local obj_name
+    obj_name="$(echo "${rel%.c}" | tr '/' '_').o"
+    emcc -O2 -sMEMORY64 -fPIC -w \
+         -I"$LEAN_INCLUDE" \
+         -include lean/config.h \
+         -include "$OVERRIDE_H" \
+         -c "$src" \
+         -o "$STAGING/lib/$obj_name"
+}
+export -f compile_wrapper
+export IR_ROOT LEAN_INCLUDE OVERRIDE_H STAGING
+if [ -d "$IR_ROOT" ]; then
+    # Gather the source list (skip Main.c and the Tests subtree).
+    mapfile -d '' -t _ir_srcs < <(
+        find "$IR_ROOT" -name '*.c' \
+            ! -name 'Main.c' \
+            ! -path "$IR_ROOT/Tests/*" \
+            -print0)
+    WRAPPER_COUNT=${#_ir_srcs[@]}
+    printf '%s\0' "${_ir_srcs[@]}" \
+        | xargs -0 -P "$JOBS" -I '{}' bash -c 'compile_wrapper "$@"' _ '{}'
+    for src in "${_ir_srcs[@]}"; do
+        rel="${src#"$IR_ROOT"/}"
+        WRAPPER_OBJS+=("$STAGING/lib/$(echo "${rel%.c}" | tr '/' '_').o")
+    done
 fi
-echo "[sparkle-wasm] compiled $WRAPPER_COUNT Lean-generated wrappers"
+echo "[sparkle-wasm] compiled $WRAPPER_COUNT Lean-generated wrappers (all of ir/, minus Main/Tests)"
 
 rm -f "$OVERRIDE_H"
 


### PR DESCRIPTION
## Problem

The hosted lab (https://verilean.github.io/sparkle/lab/) starts a Lean kernel, but `import Sparkle.Core.Domain` (and every Sparkle namespace) fails with **"unknown namespace"**.

## Root cause (traced, not guessed)

Scanning the deployed 160 MB `xlean.wasm`: the compiled Sparkle **symbols** are present (`Sparkle_Core_Domain`, 39 `initialize_sparkle_*` module inits), but the Sparkle **`.olean` files** are absent (zero `Sparkle/Core/Domain` olean paths, while the stdlib oleans *are* embedded). Lean's `import` needs the `.olean` (module metadata), so it can't resolve the namespace.

Why the oleans were missing: `tools/wasm/build-wasm.sh` compiled only `.lake/build/ir/Sparkle/**` (49 files) into `libsparkle_wasm.a`. But the umbrella `Sparkle.olean` re-exports `IP.*`, `Tools.*`, etc., whose generated wrappers reference each other's `initialize_sparkle_<Module>` functions. The archive was therefore missing `initialize_sparkle_Sparkle` (top-level `ir/Sparkle.c`) and the `IP.*` inits (`initialize_sparkle_IP_RV32_Divider`, from `ir/IP/**`). The kernel's `wasm-ld --whole-archive libsparkle_wasm.a` then failed on those undefined symbols → the Sparkle-enabled kernel rebuild fell over → the oleans were never embedded.

## Fix

Archive **all** of `ir/**/*.c` (minus the executable `Main.c` and the `ir/Tests/` tree), compiled in parallel (~330 files, up from 49).

## Verified locally (in the docs-builder image, end-to-end)

- `build-wasm.sh` now archives **327 wrappers**.
- `test_wasm_node` built with `-DEXTRA_WASM_DIRS=<staging>` **links successfully** — previously it failed with `undefined symbol: initialize_sparkle_Sparkle` / `initialize_sparkle_IP_RV32_Divider`.
- The resulting `test_wasm_node.wasm` **contains the embedded `/lib/lean/Sparkle/Core/Domain` olean path** alongside the stdlib ones (the deployed wasm had zero Sparkle olean paths).

CI's Pages/JupyterLite job runs this `build-wasm.sh` during the xlean kernel rebuild, so the next deploy embeds the Sparkle oleans and the lab resolves `import Sparkle`.