### PR TITLE
fix(ci): repair build.yml YAML broken by the Sparkle olean-merge step (#92)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1051,22 +1051,23 @@ jobs:
               if [ -f /tmp/sparkle-pack/Sparkle-olean.tar.zst ]; then
                 cp /tmp/sparkle-pack/Sparkle-olean.tar.zst "$OLEAN_OUT/"
                 # Merge the Sparkle module entry into the existing
-                # (stdlib) manifest-v2.json.  If the stdlib manifest is
-                # absent for some reason, fall back to the freshly-packed
-                # Sparkle-only manifest.  NOTE: this whole step runs
-                # inside a `bash -eu -c '\''...'\''` single-quoted docker
-                # command, so the Python body must contain NO single
-                # quotes and the heredoc delimiter must be UNQUOTED (its
-                # body has no `$`, so nothing expands).
-                python3 - "$OLEAN_OUT/manifest-v2.json" /tmp/sparkle-pack/manifest-v2.json <<PYEOF
-import json, os, sys
-base_path, sparkle_path = sys.argv[1], sys.argv[2]
-sparkle = json.load(open(sparkle_path))
-base = json.load(open(base_path)) if os.path.exists(base_path) else {"version": "v2", "baseUrl": "", "modules": {}}
-base.setdefault("modules", {}).update(sparkle.get("modules", {}))
-json.dump(base, open(base_path, "w"))
-print("[pack] merged Sparkle into manifest-v2.json; modules now: " + ", ".join(sorted(base["modules"])))
-PYEOF
+                # (stdlib) manifest-v2.json.  This step runs inside a
+                # `bash -eu -c '\''...'\''` single-quoted docker command, and
+                # a YAML `run: |` block scalar strips the block indent —
+                # which makes an inline heredoc either break YAML (0-indent
+                # body) or break Python (dedented-but-still-indented body).
+                # So write the merge script to a file with printf (no
+                # single quotes, no heredoc) and run it.
+                printf "%s\n" \
+                  "import json, os, sys" \
+                  "b_path, s_path = sys.argv[1], sys.argv[2]" \
+                  "sp = json.load(open(s_path))" \
+                  "base = json.load(open(b_path)) if os.path.exists(b_path) else {\"version\": \"v2\", \"baseUrl\": \"\", \"modules\": {}}" \
+                  "base.setdefault(\"modules\", {}).update(sp.get(\"modules\", {}))" \
+                  "json.dump(base, open(b_path, \"w\"))" \
+                  "print(\"[pack] merged Sparkle; manifest modules: \" + \", \".join(sorted(base[\"modules\"])))" \
+                  > /tmp/merge_manifest.py
+                python3 /tmp/merge_manifest.py "$OLEAN_OUT/manifest-v2.json" /tmp/sparkle-pack/manifest-v2.json
               else
                 echo "::warning::Sparkle olean pack produced no tarball; lab will lack import Sparkle"
               fi


### PR DESCRIPTION
#92 added the Sparkle olean pack+merge, but its inline `<<PYEOF` heredoc broke the workflow YAML: GitHub reported *"This run likely failed because of a workflow file issue"*, the Pages deploy never ran, and `manifest-v2.json` still lists only `Init/Std/Lean` (no Sparkle) — so the lab is still broken.

## Why it broke

Inside a `run: |` block scalar, YAML dedents to the block base. The heredoc's Python body was at column 0 → it fell *outside* the block → YAML parse error. Indenting the body to satisfy YAML instead yields `IndentationError` in Python (the dedent leaves residual indent). Both constraints can't be met with an inline heredoc this deep in the `bash -eu -c '…'` docker command.

## Fix

Drop the heredoc; emit the merge script via `printf "%s\n" …` (no heredoc, no single quotes — `\"` passes through the outer single quotes) to `/tmp/merge_manifest.py` and run it.

## Verified

- `build.yml` now **parses as YAML** (checked with pyyaml in the docs-builder image).
- The `printf` + `python3` merge **runs correctly inside a real `bash -eu -c '…'` wrapper**, adding the Sparkle entry: manifest modules become `Init, Lean, Sparkle, Std`.

Once this deploys, the pack step from #92 runs, the manifest gains its Sparkle entry, and `import Sparkle.Core.Domain` resolves in the lab.