### PR TITLE
feat(crypto): FIDO2/CTAP2 pure data layer + P-256 sign (M1)

### DIFF
--- a/IP/Crypto/CBOR.lean
+++ b/IP/Crypto/CBOR.lean
@@ -1,0 +1,97 @@
+/-
+  IP.Crypto.CBOR — CTAP2-subset canonical CBOR encoder (RFC 8949).
+
+  FIDO2/CTAP2 messages are CBOR.  CTAP2 mandates the *canonical*
+  (CTAP2 "deterministic") form:
+    * definite-length arrays / maps only,
+    * integers / lengths encoded in the SHORTEST form,
+    * map keys sorted by their canonically-encoded byte order
+      (shorter encodings first, then lexicographic).
+
+  We implement exactly the subset a minimal authenticator emits:
+  unsigned ints, negative ints (for COSE labels like -7), byte
+  strings, text strings, arrays, and maps.
+
+  The initial byte is `(major << 5) | additionalInfo`, where the
+  argument (an unsigned value: the int itself, or a length) is
+  encoded like RLP's length-class prefix (`RLP.encodeLength`):
+    0..23   inline in additionalInfo
+    24      +1 byte    (0x18)
+    25      +2 bytes   (0x19)
+    26      +4 bytes   (0x1a)
+    27      +8 bytes   (0x1b)
+-/
+import IP.Crypto.RLP
+
+namespace Sparkle.IP.Crypto.CBOR
+
+/-- Major types. -/
+def majUint : UInt8 := 0   -- unsigned integer
+def majNint : UInt8 := 1   -- negative integer
+def majBstr : UInt8 := 2   -- byte string
+def majTstr : UInt8 := 3   -- text string
+def majArray : UInt8 := 4  -- array
+def majMap : UInt8 := 5    -- map
+
+/-- Big-endian `arg` in exactly `w` bytes (zero-padded). -/
+private def bePad (arg : Nat) (w : Nat) : Array UInt8 := Id.run do
+  let mut out : Array UInt8 := #[]
+  for i in [:w] do
+    out := out.push (UInt8.ofNat ((arg >>> ((w - 1 - i) * 8)) &&& 0xFF))
+  return out
+
+/-- The CBOR head: `(major << 5) | ai` followed by 0/1/2/4/8
+    argument bytes, in the shortest form. -/
+def hdr (major : UInt8) (arg : Nat) : Array UInt8 :=
+  let m := major.toNat <<< 5
+  if arg < 24 then
+    #[UInt8.ofNat (m ||| arg)]
+  else if arg < 0x100 then
+    #[UInt8.ofNat (m ||| 24)] ++ bePad arg 1
+  else if arg < 0x10000 then
+    #[UInt8.ofNat (m ||| 25)] ++ bePad arg 2
+  else if arg < 0x100000000 then
+    #[UInt8.ofNat (m ||| 26)] ++ bePad arg 4
+  else
+    #[UInt8.ofNat (m ||| 27)] ++ bePad arg 8
+
+/-- Unsigned integer. -/
+def uint (n : Nat) : Array UInt8 := hdr majUint n
+
+/-- Negative integer `-1 - n₀` for `n₀ ≥ 0`; the CBOR argument is
+    `-1 - value`.  E.g. COSE alg ES256 = -7 → `negInt 7` (arg 6). -/
+def negIntOfMag (mag : Nat) : Array UInt8 :=
+  -- value = -(mag);  arg encoded = mag - 1.
+  hdr majNint (mag - 1)
+
+/-- Byte string. -/
+def bstr (b : Array UInt8) : Array UInt8 := hdr majBstr b.size ++ b
+
+/-- Text string (ASCII). -/
+def tstr (s : String) : Array UInt8 :=
+  let b := s.toUTF8.toList.toArray
+  hdr majTstr b.size ++ b
+
+/-- Definite-length array of already-encoded items. -/
+def array (items : List (Array UInt8)) : Array UInt8 :=
+  hdr majArray items.length ++ (items.foldl (· ++ ·) (#[] : Array UInt8))
+
+/-- Canonical key ordering: shorter encoded key first, then
+    bytewise lexicographic (CTAP2 length-first rule). -/
+private def keyLe (a b : Array UInt8) : Bool :=
+  if a.size ≠ b.size then a.size < b.size
+  else Id.run do
+    for i in [:a.size] do
+      let x := a[i]!; let y := b[i]!
+      if x ≠ y then return x < y
+    return true
+
+/-- Definite-length map from already-encoded `(key, value)` pairs.
+    Keys are re-sorted into CTAP2 canonical order so callers may
+    pass pairs in any order. -/
+def mapPairs (pairs : List (Array UInt8 × Array UInt8)) : Array UInt8 :=
+  let sorted := pairs.toArray.qsort (fun p q => keyLe p.1 q.1) |>.toList
+  hdr majMap sorted.length ++
+    (sorted.foldl (fun acc (k, v) => acc ++ k ++ v) (#[] : Array UInt8))
+
+end Sparkle.IP.Crypto.CBOR

--- a/IP/Crypto/CTAP2Data.lean
+++ b/IP/Crypto/CTAP2Data.lean
@@ -1,0 +1,111 @@
+/-
+  IP.Crypto.CTAP2Data — FIDO2/CTAP2 data-structure builders (pure).
+
+  Builds the exact byte layouts a minimal (no-PIN, no-resident-key)
+  authenticator emits, per the WebAuthn / CTAP2 specs:
+
+    * COSE_Key for an ES256 / P-256 public key,
+    * attestedCredentialData,
+    * authenticatorData,
+    * the makeCredential and getAssertion CBOR response maps.
+
+  All pure `Nat` / `Array UInt8`; this milestone (M1) locks the
+  byte layouts before any hardware.  The hardware milestones feed
+  the same bytes through the on-chip SHA-256 + P-256 signer.
+-/
+import IP.Crypto.CBOR
+import IP.Crypto.DerSig
+import IP.Crypto.SHA256
+import IP.Crypto.P256ECDSA
+
+namespace Sparkle.IP.Crypto.CTAP2Data
+
+-- `CBOR.*` / `DerSig.*` resolve because the sibling namespaces
+-- `Sparkle.IP.Crypto.CBOR` / `.DerSig` are in scope from inside
+-- `Sparkle.IP.Crypto.CTAP2Data`.
+
+/-- SHA-256 of a byte array as 32 big-endian bytes (the pure
+    `sha256OfBytes` returns 8 × `BitVec 32`). -/
+def sha256Bytes (input : Array UInt8) : Array UInt8 := Id.run do
+  let words := Sparkle.IP.Crypto.SHA256.sha256OfBytes input
+  let mut out : Array UInt8 := #[]
+  for w in words do
+    for i in [:4] do
+      out := out.push (UInt8.ofNat ((w.toNat >>> ((3 - i) * 8)) &&& 0xFF))
+  return out
+
+/-- `n` as `width` big-endian bytes (zero-padded / truncated). -/
+def beN (n : Nat) (width : Nat) : Array UInt8 := Id.run do
+  let mut out : Array UInt8 := #[]
+  for i in [:width] do
+    out := out.push (UInt8.ofNat ((n >>> ((width - 1 - i) * 8)) &&& 0xFF))
+  return out
+
+/-! ### authenticatorData flags -/
+
+/-- makeCredential: User Present (0x01) + Attested-credential-data
+    present (0x40) = 0x45. -/
+def flagsMakeCred : UInt8 := 0x45
+/-- getAssertion: User Present only = 0x05.  (0x01 UP + 0x04 UV;
+    spec's minimal example uses 0x05 = UP+UV; UP-only is 0x01.
+    We use 0x05 to mirror the common minimal authenticator.) -/
+def flagsGetAssertion : UInt8 := 0x05
+
+/-! ### COSE_Key for ES256 / P-256 -/
+
+/-- COSE_Key CBOR map for an EC2 / ES256 / P-256 public key:
+      { 1: 2 (kty EC2), 3: -7 (alg ES256), -1: 1 (crv P-256),
+        -2: bstr x(32), -3: bstr y(32) }
+    Keys are emitted in canonical order by `CBOR.mapPairs`. -/
+def coseKeyP256 (x y : Nat) : Array UInt8 :=
+  CBOR.mapPairs [
+    (CBOR.uint 1,          CBOR.uint 2),          -- kty: EC2
+    (CBOR.uint 3,          CBOR.negIntOfMag 7),   -- alg: ES256 (-7)
+    (CBOR.negIntOfMag 1,   CBOR.uint 1),          -- crv: P-256 (label -1 → 1)
+    (CBOR.negIntOfMag 2,   CBOR.bstr (beN x 32)), -- x (label -2)
+    (CBOR.negIntOfMag 3,   CBOR.bstr (beN y 32))  -- y (label -3)
+  ]
+
+/-! ### attestedCredentialData -/
+
+/-- `aaguid(16) ‖ credIdLen(2 BE) ‖ credId ‖ COSE_Key`. -/
+def attestedCredData (aaguid credId : Array UInt8) (x y : Nat) : Array UInt8 :=
+  aaguid ++ beN credId.size 2 ++ credId ++ coseKeyP256 x y
+
+/-! ### authenticatorData -/
+
+/-- `rpIdHash(32) ‖ flags(1) ‖ signCount(4 BE) ‖ [attestedCredData]`. -/
+def authenticatorData (rpIdHash : Array UInt8) (flags : UInt8)
+    (signCount : Nat) (attCred : Option (Array UInt8)) : Array UInt8 :=
+  rpIdHash ++ #[flags] ++ beN signCount 4 ++ (attCred.getD #[])
+
+/-! ### Response CBOR maps -/
+
+/-- makeCredential response: `{ 1: "packed", 2: bstr authData,
+    3: { alg: -7, sig: bstr DER } }`.  (Keys 1/2/3 = fmt / authData
+    / attStmt; attStmt keys are text strings "alg"/"sig".) -/
+def makeCredentialResponse (authData sigDer : Array UInt8) : Array UInt8 :=
+  let attStmt := CBOR.mapPairs [
+    (CBOR.tstr "alg", CBOR.negIntOfMag 7),
+    (CBOR.tstr "sig", CBOR.bstr sigDer)
+  ]
+  CBOR.mapPairs [
+    (CBOR.uint 1, CBOR.tstr "packed"),
+    (CBOR.uint 2, CBOR.bstr authData),
+    (CBOR.uint 3, attStmt)
+  ]
+
+/-- getAssertion response: `{ 1: { id: bstr credId, type:
+    "public-key" }, 2: bstr authData, 3: bstr DER }`. -/
+def getAssertionResponse (credId authData sigDer : Array UInt8) : Array UInt8 :=
+  let credential := CBOR.mapPairs [
+    (CBOR.tstr "id",   CBOR.bstr credId),
+    (CBOR.tstr "type", CBOR.tstr "public-key")
+  ]
+  CBOR.mapPairs [
+    (CBOR.uint 1, credential),
+    (CBOR.uint 2, CBOR.bstr authData),
+    (CBOR.uint 3, CBOR.bstr sigDer)
+  ]
+
+end Sparkle.IP.Crypto.CTAP2Data

--- a/IP/Crypto/DerSig.lean
+++ b/IP/Crypto/DerSig.lean
@@ -1,0 +1,54 @@
+/-
+  IP.Crypto.DerSig — ASN.1 DER encoder for an ECDSA signature.
+
+  CTAP2 (and TLS 1.3, X.509) carry an ECDSA signature as the
+  DER encoding of
+
+    SEQUENCE { INTEGER r, INTEGER s }
+
+  i.e. `30 <len> 02 <rlen> <r-bytes> 02 <slen> <s-bytes>`.
+
+  The one subtlety is the DER INTEGER rule: the value is a
+  big-endian two's-complement integer with the MINIMUM number of
+  bytes, so a positive value whose most-significant byte has its
+  high bit set (≥ 0x80) must be prefixed with a `0x00` byte to
+  keep it positive.  Getting this wrong is the classic ECDSA-DER
+  interop bug; `P256ECDSA.parseDerSignature` decodes exactly this
+  shape, so the round-trip test is the oracle.
+
+  This is the *encode* direction (the repo already had
+  `parseDerSignature`); it produces the `sig` bytes that CTAP2's
+  attStmt / assertion responses carry.
+-/
+import IP.Crypto.RLP
+import IP.Crypto.P256ECDSA
+
+namespace Sparkle.IP.Crypto.DerSig
+
+open Sparkle.IP.Crypto.RLP (beBytes)
+
+/-- Big-endian minimal bytes of `n`, with a leading `0x00` when
+    the top byte's high bit is set (DER positive-INTEGER rule).
+    `0` encodes as a single `0x00` byte. -/
+def intBytes (n : Nat) : Array UInt8 :=
+  let raw := beBytes n
+  if raw.isEmpty then #[0x00]
+  else if raw[0]!.toNat ≥ 0x80 then #[0x00] ++ raw
+  else raw
+
+/-- Encode one DER INTEGER: `02 <len> <intBytes>`. -/
+def encodeIntDer (n : Nat) : Array UInt8 :=
+  let body := intBytes n
+  #[0x02, UInt8.ofNat body.size] ++ body
+
+/-- Encode an ECDSA signature `(r, s)` as DER
+    `SEQUENCE { INTEGER r, INTEGER s }`.
+
+    P-256 signatures are ≤ 72 bytes total, so the SEQUENCE length
+    fits in one byte (< 0x80) — matching the single-byte-length
+    assumption in `P256ECDSA.parseDerSignature`. -/
+def encodeDerSig (r s : Nat) : Array UInt8 :=
+  let inner := encodeIntDer r ++ encodeIntDer s
+  #[0x30, UInt8.ofNat inner.size] ++ inner
+
+end Sparkle.IP.Crypto.DerSig

--- a/IP/Crypto/P256ECDSA.lean
+++ b/IP/Crypto/P256ECDSA.lean
@@ -109,4 +109,28 @@ def digestToNat (digest : Array UInt8) : Nat := Id.run do
     z := (z <<< 8) ||| digest[i]!.toNat
   return z
 
+/-- ECDSA sign on P-256 with a caller-provided nonce `k`.
+
+    `r = (k·G).x mod n`, `s = k⁻¹·(z + r·d) mod n`.  Returns
+    `(r, s)`, or `none` on the degenerate `r = 0` / `s = 0` cases
+    (the caller must then retry with a fresh `k`).
+
+    Exact analogue of `Secp256k1ECDSA.sign`, on the P-256 curve.
+    The nonce `k` must be uniformly random and secret; a real
+    device derives it via RFC 6979 (HMAC-DRBG over `d‖z`) or a
+    TRNG — this function takes `k` as an input, like the hardware
+    signer, and does NOT itself provide entropy. -/
+def sign (d k z : Nat) : Option (Nat × Nat) :=
+  let kg := mulScalar k base
+  match kg with
+  | .infinity => none
+  | .affine x1 _ =>
+    let r := x1 % n
+    if r = 0 then none
+    else
+      let kInv := invModN k
+      let s := (kInv * ((z + r * d) % n)) % n
+      if s = 0 then none
+      else some (r, s)
+
 end Sparkle.IP.Crypto.P256ECDSA

--- a/Tests/AllTests.lean
+++ b/Tests/AllTests.lean
@@ -153,6 +153,7 @@ import Tests.IP.Crypto.EcdsaSignDemoTest
 import Tests.IP.Crypto.TxPolicyTest
 import Tests.IP.Crypto.Keccak256SpongeTest
 import Tests.IP.Crypto.PolicySignDemoTest
+import Tests.IP.Crypto.CTAP2DataTest
 import Tests.IP.Crypto.SHA512BlockHWTest
 import Tests.IP.Crypto.HMACSHA512HWTest
 import Tests.IP.Crypto.BIP32CKDHWTest
@@ -615,6 +616,8 @@ def main : IO UInt32 := do
   Sparkle.Tests.IP.Crypto.Keccak256SpongeTest.main
   IO.println ""
   Sparkle.Tests.IP.Crypto.PolicySignDemoTest.main
+  IO.println ""
+  Sparkle.Tests.IP.Crypto.CTAP2DataTest.main
   IO.println ""
   Sparkle.Tests.IP.Crypto.SHA512BlockHWTest.main
   IO.println ""

--- a/Tests/Drivers/CTAP2DataTestMain.lean
+++ b/Tests/Drivers/CTAP2DataTestMain.lean
@@ -1,0 +1,3 @@
+import Tests.IP.Crypto.CTAP2DataTest
+
+def main : IO Unit := Sparkle.Tests.IP.Crypto.CTAP2DataTest.main

--- a/Tests/IP/Crypto/CTAP2DataTest.lean
+++ b/Tests/IP/Crypto/CTAP2DataTest.lean
@@ -1,0 +1,138 @@
+/-
+  Test for the FIDO2/CTAP2 pure data layer (M1).
+
+  Validates the byte layouts a minimal authenticator emits, BEFORE
+  any hardware, so the HW milestones have a locked reference:
+
+  1. `authenticatorData` structure — exact field offsets.
+  2. DER signature round-trips through `P256ECDSA.parseDerSignature`.
+  3. END-TO-END: sign `authData ‖ clientDataHash` with P-256 and
+     verify with the derived public key — the golden oracle that
+     ties the hash, the signature, and the encoded bytes together.
+  4. CBOR canonical map-key ordering + COSE key shape.
+
+  Pure-data only (no `#synthesizeVerilog`, no iverilog) — this is
+  the byte-layout lock, like the RLP / SHA-256 pure layers.
+-/
+import IP.Crypto.CTAP2Data
+import IP.Crypto.CBOR
+import IP.Crypto.DerSig
+import IP.Crypto.P256ECDSA
+import IP.Crypto.P256Point
+
+open Sparkle.IP.Crypto.CTAP2Data
+open Sparkle.IP.Crypto
+
+namespace Sparkle.Tests.IP.Crypto.CTAP2DataTest
+
+private def hex (bs : Array UInt8) : String := Id.run do
+  let d := fun n => "0123456789abcdef".toList.getD n '?'
+  let mut s := ""
+  for b in bs do s := s.push (d (b.toNat / 16)) |>.push (d (b.toNat % 16))
+  return s
+
+/-- Fixed test fixtures. -/
+private def rpId : String := "example.com"
+private def d : Nat := 0xC9AFA9D845BA75166B5C215767B1D6934E50C3DB36E89B127B8A622B120F6721
+private def k : Nat := 0x9E56F509196784D963D1C0A401510EE7ADA3DCC5DEE04B154BF61AF1D5A6DECE
+private def clientDataHash : Array UInt8 := Array.replicate 32 0xAB
+private def aaguid : Array UInt8 := Array.replicate 16 0x00
+private def credId : Array UInt8 := Array.replicate 16 0x42
+private def signCount : Nat := 1
+
+def main : IO Unit := do
+  IO.println "=== FIDO2/CTAP2 pure data layer — byte-layout + end-to-end check ==="
+  (← IO.getStdout).flush
+  let mut ok := true
+
+  -- Public key coordinates from the private scalar.
+  let (qx, qy) := match P256ECDSA.derivePublicKey d with
+    | .affine x y => (x, y)
+    | .infinity   => (0, 0)
+
+  -- rpIdHash = SHA-256(rpId).
+  let rpIdHash := sha256Bytes rpId.toUTF8.toList.toArray
+
+  -- ---- 1. authenticatorData layout ----
+  let attCred := attestedCredData aaguid credId qx qy
+  let authDataMC := authenticatorData rpIdHash flagsMakeCred signCount (some attCred)
+  let authDataGA := authenticatorData rpIdHash flagsGetAssertion signCount none
+  -- getAssertion authData is exactly 37 bytes (32+1+4).
+  if authDataGA.size == 37 then
+    IO.println "  ✓ getAssertion authData is 37 bytes"
+  else
+    IO.println s!"  ✗ getAssertion authData size = {authDataGA.size} (expect 37)"; ok := false
+  -- field offsets: [0:32]=rpIdHash, [32]=flags, [33:37]=signCount BE.
+  let rpMatch := (authDataGA.extract 0 32) == rpIdHash
+  let flagMatch := authDataGA[32]! == flagsGetAssertion
+  let scMatch := (authDataGA.extract 33 37) == #[0,0,0,1]
+  if rpMatch && flagMatch && scMatch then
+    IO.println "  ✓ authData fields (rpIdHash‖flags‖signCount) at correct offsets"
+  else
+    IO.println s!"  ✗ authData field mismatch rp={rpMatch} flag={flagMatch} sc={scMatch}"; ok := false
+  -- makeCredential authData starts with the same 37 bytes then attCred.
+  if (authDataMC.extract 0 37) == (authenticatorData rpIdHash flagsMakeCred signCount none) then
+    IO.println s!"  ✓ makeCredential authData = header ‖ attestedCredData ({authDataMC.size} B)"
+  else
+    IO.println "  ✗ makeCredential authData header mismatch"; ok := false
+
+  -- ---- 2. DER round-trip ----
+  -- Sign the makeCredential attestation message = authDataMC ‖ clientDataHash.
+  let msgMC := authDataMC ++ clientDataHash
+  let zMC := P256ECDSA.digestToNat (sha256Bytes msgMC)
+  match P256ECDSA.sign d k zMC with
+  | none => IO.println "  ✗ P256 sign returned none"; ok := false
+  | some (r, s) =>
+    let der := DerSig.encodeDerSig r s
+    match P256ECDSA.parseDerSignature der with
+    | some (r', s') =>
+      if r' == r && s' == s then
+        IO.println s!"  ✓ DER sig round-trips (len {der.size})"
+      else
+        IO.println s!"  ✗ DER round-trip mismatch"; ok := false
+    | none => IO.println "  ✗ parseDerSignature failed"; ok := false
+
+    -- ---- 3. END-TO-END verify ----
+    let q := P256ECDSA.derivePublicKey d
+    if P256ECDSA.verify q zMC r s then
+      IO.println "  ✓ end-to-end: verify(Q, H(authData‖clientDataHash), r, s) = true"
+    else
+      IO.println "  ✗ end-to-end verify FAILED"; ok := false
+
+    -- ---- responses assemble (smoke) ----
+    let mcResp := makeCredentialResponse authDataMC der
+    -- getAssertion over its own 37-byte authData.
+    let zGA := P256ECDSA.digestToNat (sha256Bytes (authDataGA ++ clientDataHash))
+    match P256ECDSA.sign d k zGA with
+    | some (rg, sg) =>
+      let gaResp := getAssertionResponse credId authDataGA (DerSig.encodeDerSig rg sg)
+      IO.println s!"  ✓ responses built: makeCred {mcResp.size}B, getAssertion {gaResp.size}B"
+      -- getAssertion end-to-end
+      if P256ECDSA.verify q zGA rg sg then
+        IO.println "  ✓ end-to-end getAssertion verify = true"
+      else
+        IO.println "  ✗ getAssertion verify FAILED"; ok := false
+    | none => IO.println "  ✗ getAssertion sign none"; ok := false
+
+  -- ---- 4. COSE key + CBOR canonical shape ----
+  -- COSE map first byte = 0xA5 (map, 5 entries).
+  let cose := coseKeyP256 qx qy
+  if cose[0]! == 0xA5 then
+    IO.println "  ✓ COSE_Key is a 5-entry CBOR map (0xA5)"
+  else
+    IO.println s!"  ✗ COSE_Key first byte = {hex #[cose[0]!]} (expect a5)"; ok := false
+  -- canonical key order: uint keys (1,3) sort before negInt keys (-1,-2,-3);
+  -- CBOR.mapPairs must have re-sorted them.  A tiny direct check:
+  let m := CBOR.mapPairs [(CBOR.uint 3, CBOR.uint 0), (CBOR.uint 1, CBOR.uint 0)]
+  -- expect: a2 (map2) 01 00 03 00  — key 1 before key 3.
+  if m == #[0xA2, 0x01, 0x00, 0x03, 0x00] then
+    IO.println "  ✓ CBOR map keys sorted canonically (1 before 3)"
+  else
+    IO.println s!"  ✗ CBOR key sort wrong: {hex m}"; ok := false
+
+  if !ok then
+    IO.println "\nFAIL"
+    IO.Process.exit 1
+  IO.println "\nALL PASS"
+
+end Sparkle.Tests.IP.Crypto.CTAP2DataTest

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -711,6 +711,10 @@ lean_exe «policy-sign-demo-test» where
   root := `Tests.Drivers.PolicySignDemoTestMain
   supportInterpreter := true
 
+lean_exe «ctap2-data-test» where
+  root := `Tests.Drivers.CTAP2DataTestMain
+  supportInterpreter := true
+
 lean_exe «sha512-block-hw-test» where
   root := `Tests.Drivers.SHA512BlockHWTestMain
   supportInterpreter := true


### PR DESCRIPTION
## Summary

First milestone of a **FIDO2/CTAP2 authenticator** for Tang Nano 50K
(Google/GitHub login), verified first over the BL616 CDC-ACM UART bridge.
**M1 locks the exact CTAP2 byte layouts** before any hardware — all pure
`Nat` / `Array UInt8`, so the HW milestones (M2 P-256 sign stack, M3
CTAPHID/CBOR/UART top) have a golden reference.

## New

- **`IP/Crypto/P256ECDSA.lean`** — add `sign (d k z) : Option (Nat×Nat)`, the
  P-256 analogue of `Secp256k1ECDSA.sign`. Nonce `k` is an input (as in the
  HW signer); RFC-6979 deterministic-k is a later milestone.
- **`IP/Crypto/DerSig.lean`** — `encodeIntDer` / `encodeDerSig (r s)`: ASN.1
  DER `SEQUENCE { INTEGER r, INTEGER s }` with the positive-integer `0x00`-pad
  rule. Round-trips through the existing `parseDerSignature`.
- **`IP/Crypto/CBOR.lean`** — CTAP2-canonical CBOR subset (definite-length,
  shortest-form ints, map keys sorted length-first): `hdr/uint/negInt/bstr/
  tstr/array/mapPairs`, mirroring `RLP.encodeLength`.
- **`IP/Crypto/CTAP2Data.lean`** — `coseKeyP256`, `attestedCredData`,
  `authenticatorData`, `makeCredentialResponse`, `getAssertionResponse` (exact
  WebAuthn/CTAP2 field layouts; flags `0x45`/`0x05`).

## Verify — `ctap2-data-test`, ALL PASS

- getAssertion authData = **37 B**; rpIdHash/flags/signCount at correct
  offsets; makeCredential authData = header ‖ attestedCredData (**148 B**).
- DER sig **round-trips** (71 B) through `parseDerSignature`.
- **End-to-end**: `verify(Q, SHA256(authData‖clientDataHash), r, s) = true` for
  both makeCredential and getAssertion — the golden oracle tying hash +
  signature + encoded bytes together.
- COSE_Key is a 5-entry map (`0xA5`); CBOR canonical key ordering verified.

Wired into `lake test` (`ctap2-data-test` + AllTests). Pure-data only (no
synth/iverilog), like the RLP / SHA-256 pure layers.

## Roadmap (this is 1 of 3 this cycle)

- **M2**: P-256 HW sign stack (point-op a=−3, scalar-mul, mod-n, signHW)
  mirroring the secp256k1 stack + SHA-256 streaming wrapper.
- **M3**: CTAPHID 64-byte report framing + CTAP2 dispatch FSM + byte-serial
  CBOR emitter → Tang Nano UART-bridge top; register/authenticate on
  webauthn.io via a host shim.
- M4 (soft USB-FS native HID) and M5 (PIN/hmac-secret/TRNG) are planned,
  deferred to later sessions.