### PR TITLE
fix: repoint #101's stale crypto imports at #100's relocated modules

### DIFF
--- a/IP/Crypto/EcdsaSignSmall.lean
+++ b/IP/Crypto/EcdsaSignSmall.lean
@@ -25,8 +25,8 @@
 import Sparkle
 import IP.Crypto.Secp256k1FieldHW
 import IP.Crypto.Secp256k1OrderHW
-import IP.Crypto.Secp256k1Field
-import IP.Crypto.Secp256k1ECDSA
+import IP.Crypto.Proof.Secp256k1Field
+import IP.Crypto.Proof.Secp256k1ECDSA
 
 open Sparkle.Core.Domain
 open Sparkle.Core.Signal

--- a/IP/Crypto/EcdsaSignSmallDemo.lean
+++ b/IP/Crypto/EcdsaSignSmallDemo.lean
@@ -9,7 +9,7 @@
 -/
 import Sparkle
 import IP.Crypto.EcdsaSignSmall
-import IP.Crypto.Secp256k1PointJac
+import IP.Crypto.Proof.Secp256k1PointJac
 import IP.Net.UART
 
 open Sparkle.Core.Domain Sparkle.Core.Signal

--- a/IP/Crypto/Rfc6979.lean
+++ b/IP/Crypto/Rfc6979.lean
@@ -11,7 +11,7 @@
       against `derivePublicKey d`.
 -/
 import IP.Crypto.SHA256
-import IP.Crypto.Secp256k1ECDSA
+import IP.Crypto.Proof.Secp256k1ECDSA
 
 namespace Sparkle.IP.Crypto.Rfc6979
 

--- a/IP/Crypto/Rfc6979HW.lean
+++ b/IP/Crypto/Rfc6979HW.lean
@@ -13,7 +13,7 @@
 -/
 import Sparkle
 import IP.Crypto.HMACSHA256HW
-import IP.Crypto.Secp256k1ECDSA
+import IP.Crypto.Proof.Secp256k1ECDSA
 
 namespace Sparkle.IP.Crypto.Rfc6979HW
 

--- a/Tests/Drivers/AddIPJIT.lean
+++ b/Tests/Drivers/AddIPJIT.lean
@@ -1,5 +1,5 @@
 import Sparkle.Core.JIT
-import IP.Crypto.Secp256k1PointJac
+import IP.Crypto.Proof.Secp256k1PointJac
 open Sparkle.Core.JIT
 open Sparkle.IP.Crypto.Secp256k1PointJac
 -- ladderEngine ports: runStart=0 loadEn=1 loadAddr=2 loadData=3..10 probeAddr=11 progStart=12

--- a/Tests/Drivers/AddPtJIT.lean
+++ b/Tests/Drivers/AddPtJIT.lean
@@ -1,5 +1,5 @@
 import Sparkle.Core.JIT
-import IP.Crypto.Secp256k1PointJac
+import IP.Crypto.Proof.Secp256k1PointJac
 open Sparkle.Core.JIT
 open Sparkle.IP.Crypto.Secp256k1PointJac
 def main : IO Unit := do

--- a/Tests/Drivers/DblIPJIT.lean
+++ b/Tests/Drivers/DblIPJIT.lean
@@ -1,5 +1,5 @@
 import Sparkle.Core.JIT
-import IP.Crypto.Secp256k1PointJac
+import IP.Crypto.Proof.Secp256k1PointJac
 open Sparkle.Core.JIT
 open Sparkle.IP.Crypto.Secp256k1PointJac
 -- ladderEngine ports: runStart=0 loadEn=1 loadAddr=2 loadData=3..10 probeAddr=11 progStart=12

--- a/Tests/Drivers/EcdsaSignSmallJIT.lean
+++ b/Tests/Drivers/EcdsaSignSmallJIT.lean
@@ -6,8 +6,8 @@
 -- Generate the C first:  lake env lean fpga/tangNano20k/build/GenAluSim.lean
 -- Then:                   lake exe ecdsa-sign-small-jit
 import Sparkle.Core.JIT
-import IP.Crypto.Secp256k1Field
-import IP.Crypto.Secp256k1ECDSA
+import IP.Crypto.Proof.Secp256k1Field
+import IP.Crypto.Proof.Secp256k1ECDSA
 
 open Sparkle.Core.JIT
 

--- a/Tests/Drivers/EcdsaSignSmallSim.lean
+++ b/Tests/Drivers/EcdsaSignSmallSim.lean
@@ -4,8 +4,8 @@
 --   lake exe ecdsa-sign-small-sim
 import Sparkle
 import IP.Crypto.EcdsaSignSmall
-import IP.Crypto.Secp256k1Field
-import IP.Crypto.Secp256k1ECDSA
+import IP.Crypto.Proof.Secp256k1Field
+import IP.Crypto.Proof.Secp256k1ECDSA
 
 open Sparkle.Core.Domain Sparkle.Core.Signal
 open Sparkle.IP.Crypto.EcdsaSignSmall

--- a/Tests/Drivers/ExpJIT.lean
+++ b/Tests/Drivers/ExpJIT.lean
@@ -1,6 +1,6 @@
 import Sparkle.Core.JIT
-import IP.Crypto.Secp256k1Field
-import IP.Crypto.Secp256k1ECDSA
+import IP.Crypto.Proof.Secp256k1Field
+import IP.Crypto.Proof.Secp256k1ECDSA
 open Sparkle.Core.JIT
 -- expTop ports: modN=0 expStart=1 extLoadEn=2 extLoadAddr=3 extLoadData=4..11
 --   scalarLoadEn=12 scalarIn=13..20 probeAddr=21 ; out probeVal=0..7 halted=8

--- a/Tests/Drivers/KeccakFJIT.lean
+++ b/Tests/Drivers/KeccakFJIT.lean
@@ -1,5 +1,5 @@
 import Sparkle.Core.JIT
-import IP.Crypto.Keccak256
+import IP.Crypto.Proof.Keccak256
 open Sparkle.Core.JIT
 open Sparkle.IP.Crypto.Keccak256 (keccakF State)
 

--- a/Tests/Drivers/KeccakSpongeJIT.lean
+++ b/Tests/Drivers/KeccakSpongeJIT.lean
@@ -1,5 +1,5 @@
 import Sparkle.Core.JIT
-import IP.Crypto.Keccak256
+import IP.Crypto.Proof.Keccak256
 open Sparkle.Core.JIT
 open Sparkle.IP.Crypto.Keccak256 (keccak256OfBytes padEthereum rateBytes)
 -- keccakSpongeTop ports (64-bit values are single slots in this JIT ABI):

--- a/Tests/Drivers/LadderJIT.lean
+++ b/Tests/Drivers/LadderJIT.lean
@@ -1,5 +1,5 @@
 import Sparkle.Core.JIT
-import IP.Crypto.Secp256k1PointJac
+import IP.Crypto.Proof.Secp256k1PointJac
 open Sparkle.Core.JIT
 open Sparkle.IP.Crypto.Secp256k1PointJac
 -- inputs: ladderStart=0 extLoadEn=1 extLoadAddr=2 extLoadData=3..10

--- a/Tests/Drivers/PdJIT.lean
+++ b/Tests/Drivers/PdJIT.lean
@@ -1,5 +1,5 @@
 import Sparkle.Core.JIT
-import IP.Crypto.Secp256k1PointJac
+import IP.Crypto.Proof.Secp256k1PointJac
 open Sparkle.Core.JIT
 
 -- inputs: runStart=0 loadEn=1 loadAddr=2 loadData=3..10 probeAddr=11

--- a/Tests/Drivers/SignCoreJIT.lean
+++ b/Tests/Drivers/SignCoreJIT.lean
@@ -1,5 +1,5 @@
 import Sparkle.Core.JIT
-import IP.Crypto.Secp256k1ECDSA
+import IP.Crypto.Proof.Secp256k1ECDSA
 open Sparkle.Core.JIT
 -- signCoreTop ports: start=0 d=1..8 k=9..16 z=17..24 ; out rOut=0..7 sOut=8..15 done=16
 def main : IO Unit := do

--- a/Tests/Drivers/SignDemoJIT.lean
+++ b/Tests/Drivers/SignDemoJIT.lean
@@ -1,5 +1,5 @@
 import Sparkle.Core.JIT
-import IP.Crypto.Secp256k1ECDSA
+import IP.Crypto.Proof.Secp256k1ECDSA
 open Sparkle.Core.JIT
 -- demoTop ports: uartRx=0 bitDiv=1 ; out uartTx=0 signDone=1
 -- UART 8-N-1, bitDiv=3 → 4 cycles/bit.  Host sends 64 bytes k‖z (MSB-first),

--- a/Tests/Drivers/SignJIT.lean
+++ b/Tests/Drivers/SignJIT.lean
@@ -1,6 +1,6 @@
 import Sparkle.Core.JIT
-import IP.Crypto.Secp256k1PointJac
-import IP.Crypto.Secp256k1ECDSA
+import IP.Crypto.Proof.Secp256k1PointJac
+import IP.Crypto.Proof.Secp256k1ECDSA
 open Sparkle.Core.JIT
 open Sparkle.IP.Crypto.Secp256k1PointJac
 -- signTop ports: signStart=0 extLoadEn=1 extLoadAddr=2 extLoadData=3..10

--- a/Tests/Drivers/SignMsgDemoJIT.lean
+++ b/Tests/Drivers/SignMsgDemoJIT.lean
@@ -1,5 +1,5 @@
 import Sparkle.Core.JIT
-import IP.Crypto.Keccak256
+import IP.Crypto.Proof.Keccak256
 import IP.Crypto.Rfc6979
 open Sparkle.Core.JIT
 open Sparkle.IP.Crypto.Keccak256 (keccak256OfBytes padEthereum)

--- a/Tests/Drivers/SignMsgSmallJIT.lean
+++ b/Tests/Drivers/SignMsgSmallJIT.lean
@@ -1,5 +1,5 @@
 import Sparkle.Core.JIT
-import IP.Crypto.Keccak256
+import IP.Crypto.Proof.Keccak256
 import IP.Crypto.Rfc6979
 open Sparkle.Core.JIT
 open Sparkle.IP.Crypto.Keccak256 (keccak256OfBytes padEthereum rateBytes)

--- a/Tests/IP/Crypto/PolicySignDemoM2Test.lean
+++ b/Tests/IP/Crypto/PolicySignDemoM2Test.lean
@@ -12,8 +12,8 @@
   below proves the whole M2 top lowers to hardware.
 -/
 import Sparkle
-import IP.Crypto.Eip1559Tx
-import IP.Crypto.Secp256k1ECDSA
+import IP.Crypto.Codec.Eip1559Tx
+import IP.Crypto.Proof.Secp256k1ECDSA
 import IP.Crypto.TxPolicy
 import IP.Crypto.PolicySignDemoM2
 


### PR DESCRIPTION
`da218f4` (squash of #101) left main red: the PR branch predated #100's crypto refactor (which moved the reference impls under `IP/Crypto/Proof/` and codecs under `IP/Crypto/Codec/`, namespaces unchanged).  The squash kept #101's new files but not the old-path modules they import, so both `build` (lake exe test) and `tutorial-notebooks` failed with `bad import 'IP.Crypto.Secp256k1Field'` etc.

Fix = rewrite the stale import lines (paths only; namespaces/APIs identical):
- `IP.Crypto.{Keccak256,Secp256k1ECDSA,Secp256k1Field,Secp256k1PointJac}` → `IP.Crypto.Proof.*`
- `IP.Crypto.Eip1559Tx` → `IP.Crypto.Codec.Eip1559Tx`

20 files: the signer chain (EcdsaSignSmall(+Demo), Rfc6979(+HW), EcdsaSignMsg*), 15 JIT drivers, and PolicySignDemoM2Test.  Verified locally: `lake build IP.Crypto.EcdsaSignMsgDemo` + `Tests.IP.Crypto.PolicySignDemoM2Test` build against main.