### PR TITLE
fix(fpga): repoint GenPolicySigner at #100's relocated crypto modules

### DIFF
--- a/fpga/tangNano20k/build/GenPolicySigner.lean
+++ b/fpga/tangNano20k/build/GenPolicySigner.lean
@@ -4,8 +4,8 @@
 -- lands the whole design (all submodules) on disk. Run with:
 --   lake env lean fpga/tangNano20k/build/GenPolicySigner.lean
 import Sparkle
-import IP.Crypto.Keccak256
-import IP.Crypto.Secp256k1ECDSA
+import IP.Crypto.Proof.Keccak256
+import IP.Crypto.Proof.Secp256k1ECDSA
 import IP.Crypto.TxPolicy
 import IP.Crypto.PolicySignDemo
 


### PR DESCRIPTION
Last stale-import holdover from #101's pre-#100 branch. GenPolicySigner is a manual gen script under build/ (not built by CI), so it slipped past #102's build/tutorial-notebooks fixes. Repoint IP.Crypto.{Keccak256,Secp256k1ECDSA} → IP.Crypto.Proof.* (namespaces unchanged). Verified locally: the script runs and regenerates policy_signer.v (13 modules).