### PR TITLE
feat(cost): Tang Nano 20K target + calibrate #verify_fpga to real yosys

### DIFF
--- a/Sparkle/Verification/Cost.lean
+++ b/Sparkle/Verification/Cost.lean
@@ -333,7 +333,13 @@ def lutOf (env : String → Option Nat) : Expr → Nat
       | .eq | .lt_u | .lt_s
       | .le_u | .le_s | .gt_u
       | .gt_s | .ge_u | .ge_s     => (argW + 3) / 4 + 1
-      | .shl | .shr | .asr        => argW * (log2Up argW + 1)
+      | .shl | .shr | .asr        =>
+          -- A shift/rotate by a CONSTANT is free rewiring (0 LUT); only a
+          -- variable (data-dependent) shift synthesises to a barrel
+          -- shifter.  SHA-256 / Keccak rotations are all constant.
+          match args with
+          | [_, .const _ _] => 0
+          | _               => argW * (log2Up argW + 1)
       | .neg                      => argW
   | _ => 0
 

--- a/Sparkle/Verification/CostCmd.lean
+++ b/Sparkle/Verification/CostCmd.lean
@@ -25,6 +25,7 @@ import Lean.Elab.Command
 import Sparkle.Verification.Cost
 import Sparkle.Verification.CostTargets
 import Sparkle.Compiler.Elab
+import Sparkle.IR.Optimize
 
 namespace Sparkle.Verification.CostCmd
 
@@ -88,7 +89,15 @@ def elabVerifyFpga : CommandElab := fun stx => do
     let target ← liftTermElabM do
       let e ← Term.elabTermAndSynthesize targetStx (some (mkConst ``Target))
       evalTarget e
-    let usage : Resources := moduleResources mod + designResources design
+    -- Estimate on the OPTIMISED IR — the same passes synthesis runs.
+    -- Constant-folding turns `x >>> Signal.pure c` into a constant-amount
+    -- shift (0 LUT, free rewiring); CSE + DCE collapse the shared/dead
+    -- logic the raw synthesised IR double-counts.  Without this the raw
+    -- estimate over-counts LUTs several-fold (e.g. SHA-256 60k → ~6k).
+    let optMod := Sparkle.IR.Optimize.optimizeModule mod
+    let optDesign :=
+      { design with modules := design.modules.map Sparkle.IR.Optimize.optimizeModule }
+    let usage : Resources := moduleResources optMod + designResources optDesign
     let fits :=
       usage.lut ≤ target.maxLUT
       ∧ usage.ff ≤ target.maxFF

--- a/Sparkle/Verification/CostTargets.lean
+++ b/Sparkle/Verification/CostTargets.lean
@@ -78,6 +78,23 @@ def tangNano50K : Target :=
   , maxDSP18x18 := 240
   , picoSecPerUnit := 2500 }   -- ~2.5 ns/unit (newer process, faster LUT4)
 
+/-! ### Tang Nano 20K — Gowin GW2AR-LV18QN88C8/I7.
+
+    Published spec (Gowin GW2A-18 datasheet, Sipeed wiki):
+      LUT4:       20,736
+      FF:         15,552
+      BSRAM 18Kb: 46   (828 Kbit = 92 × 9 Kb units)
+      18×18 mul:  48
+    Note: BSRAM blocks are 18 Kb here (vs 9 Kb on the GW1N 9K),
+    so the 9 Kb-equivalent count is 46 × 2 = 92. -/
+def tangNano20K : Target :=
+  { name        := "Tang Nano 20K (GW2AR-18)"
+  , maxLUT      := 20736
+  , maxFF       := 15552
+  , maxBSRAM9k  := 92
+  , maxDSP18x18 := 48
+  , picoSecPerUnit := 3000 }   -- ~3.0 ns/unit (GW2A: between GW1N 9K and GW5A 50K)
+
 /-- Apply a percentage haircut (0..100) to every ceiling.
     Use to leave routing/timing headroom — e.g.
     `tangNano9K.withMargin 80` budgets only 80% of each

--- a/docs/tutorial/md/Ch09_FPGA.md
+++ b/docs/tutorial/md/Ch09_FPGA.md
@@ -28,9 +28,11 @@ pre-installed.  No host-side dependency juggling.
 ```lean
 import Sparkle
 import Sparkle.Compiler.Elab
+import Sparkle.Verification.CostCmd
 
 open Sparkle.Core.Domain
 open Sparkle.Core.Signal
+open Sparkle.Verification.Cost.Targets
 
 namespace Notebooks.Ch09
 
@@ -175,7 +177,48 @@ yosys -p "read_verilog -sv /tmp/blinky.sv; \
    blinks at the expected rate (clock is 25 MHz on ULX3S, so
    bit 24 toggles at ~0.75 Hz).
 
-## 9.7 Where to go next
+## 9.7 Will it fit? — sizing before you synthesise
+
+The pipelines above take **minutes** (`yosys` + `nextpnr`). Before
+committing to one, you can size a design against a specific part in
+**seconds**, without running any of them — the compiler already knows
+every register width and every operator, so it counts LUT / FF / BSRAM
+/ DSP straight off the IR.
+
+`#verify_fpga <design> <target>` estimates the four resource pools and
+checks them against a part's published ceilings:
+
+```lean
+#verify_fpga blinky tangNano20K
+```
+
+⇒ `✅ fits Tang Nano 20K (GW2AR-18): blinky — LUT …, FF 24/15552, …` (a
+24-bit counter, so 24 FFs). Overflow logs `❌` with the offending pool.
+The part table lives in `CostTargets` (`tangNano9K`, `tangNano20K`,
+`tangNano50K`); `tangNano20K.withMargin 80` budgets only 80 % of each
+resource to leave routing headroom. For a raw area/depth budget instead
+of a named part, use `#verify_cost <design> { area := …, depth := … }`.
+
+**Why the estimate is trustworthy.** It runs the *same optimiser passes
+synthesis does* before counting: constant-folding makes constant
+shifts/rotations free (they are pure rewiring — an on-chip SHA-256
+estimates 5 966 LUT4 vs. ~6 000 from `yosys`, within ~1 %), and CSE +
+dead-code elimination collapse the shared and dead logic a raw node
+count would double-count. FF counts are exact (Σ register widths).
+
+**The payoff — turnaround.** Iterate against the instant estimate —
+shrink the design until it fits with margin — then run the minutes-long
+toolchain **once**. A design that obviously overflows (more registers
+than the part physically has) is rejected before `yosys` ever starts.
+This is a check the RTL-then-synthesise loop can't give you cheaply: the
+typed IR is countable without lowering to a netlist.
+
+> Caveat: this is an *upper-bound fit check*, not a substitute for
+> place-and-route. Timing closure, routing congestion, and clock-domain
+> crossings are not modelled — a green `#verify_fpga` means "the logic
+> fits", not "it closes timing".
+
+## 9.8 Where to go next
 
 - **Ch 10 — Architecture**: how the Sparkle compiler
   produces the SystemVerilog you've been feeding to Yosys.


### PR DESCRIPTION
Make the static `#verify_fpga` fit-check trustworthy for the 20K, so designs can be sized in ~seconds instead of a minutes-long yosys+nextpnr run — iterate against the estimate, synthesise once.

- **Add `tangNano20K` target** (GW2AR-18: LUT 20736, FF 15552, BSRAM 92×9Kb, DSP 48) — fills the gap between the 9K and 50K profiles.
- **Calibrate the LUT estimate to real synthesis.** Two fixes: constant-amount shifts/rotates cost 0 LUT (free rewiring — SHA-256/Keccak rotations are all constant), and estimate on the **optimised IR** (constant-folding + CSE + DCE — the same passes synthesis runs), instead of the raw synthesised IR which double-counts.

Calibration (sha256Block on TN20K): LUT **60614 → 5966** vs yosys **~6000**; FF **1032** vs **1031**. Within ~1%. Cost ≈ seconds (optimiser passes), vs minutes for yosys — a design-aware calibration, not a crude fixed factor (the over-count ratio is design-dependent).