### PR TITLE
docs(tutorial): Verilog syntax table, Signal-level LTL, FPGA → Tang Nano 20K

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1188,6 +1188,7 @@ jobs:
           echo '  <li><a href="tutorial/">Tutorial</a> — chapter-by-chapter walk-through of the Signal DSL, register patterns, Verilog synthesis, formal proofs, and FPGA bring-up.</li>'
           echo '  <li><a href="lab/">JupyterLite</a> — run the tutorial chapters in your browser (xlean WASM kernel, no install required).</li>'
           echo '  <li><a href="api/">API reference</a> — generated from source by <code>doc-gen4</code>. Covers <code>Sparkle.Core</code>, every <code>IP.*</code> library, the SVParser toolchain, and the Display helpers.</li>'
+          echo '  <li><a href="https://verilean.github.io/xeus-lean/tutorial/">Lean 4 syntax tutorial</a> — the xeus-lean tutorial: a quick reference for the Lean 4 language itself (syntax, tactics, notation) that Sparkle is written in.</li>'
           echo '</ul>'
           echo '<h2>Benchmarks</h2>'
           echo '<ul>'

--- a/docs/tutorial/Notebooks.lean
+++ b/docs/tutorial/Notebooks.lean
@@ -10,6 +10,7 @@ import Notebooks.Gen.Ch07_Equivalence
 import Notebooks.Gen.Ch07b_FpQuantEquivalence
 import Notebooks.Gen.Ch08_Yosys
 import Notebooks.Gen.Ch08b_Simulation
+import Notebooks.Gen.Ch08c_Silicon
 import Notebooks.Gen.Ch09_FPGA
 import Notebooks.Gen.Ch10_Architecture
 import Notebooks.Gen.Ch11_Web3Signer

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -42,6 +42,7 @@ automatically.
 | 7 | Proofs: Equivalence Checking | [`md/Ch07_Equivalence.md`](md/Ch07_Equivalence.md) |
 | 8 | Netlist Generation with Yosys | [`md/Ch08_Yosys.md`](md/Ch08_Yosys.md) |
 | 8b | Three Ways to Simulate, One Interface (pure-Lean / JIT / Verilator) | [`md/Ch08b_Simulation.md`](md/Ch08b_Simulation.md) |
+| 8c | From Signal to Silicon — DFF, clocks, STA, gate count, ASIC vs FPGA mapping | [`md/Ch08c_Silicon.md`](md/Ch08c_Silicon.md) |
 | 9 | FPGA Bring-Up | [`md/Ch09_FPGA.md`](md/Ch09_FPGA.md) |
 | 10 | Sparkle Architecture | [`md/Ch10_Architecture.md`](md/Ch10_Architecture.md) |
 | 11 | Running the web3 Signing Device on Real Hardware | [`md/Ch11_Web3Signer.md`](md/Ch11_Web3Signer.md) |

--- a/docs/tutorial/md/Ch05_Verilog.md
+++ b/docs/tutorial/md/Ch05_Verilog.md
@@ -389,7 +389,52 @@ let `bv_decide` (or `decide` on small finite types) finish off the
 residual bit-vector goal.  Ch 6 takes this further with
 temporal-logic invariants over multi-cycle behaviour.
 
-## 5.6 Where to go next
+## 5.6 Sparkle ↔ Verilog syntax reference
+
+Sparkle overloads the ordinary Lean operators on `Signal`, so a
+combinational expression reads almost exactly like the Verilog it
+produces — **no applicative plumbing**. Reach for the operator, never
+`(· op ·) <$> a <*> b`: the operator *is* that lift (identical hardware)
+and costs a fraction of the tokens.
+
+| Operation | Sparkle (`Signal dom …`) | Verilog | Notes |
+|---|---|---|---|
+| add / sub / mul | `a + b`, `a - b`, `a * b` | `a + b`, `a - b`, `a * b` | |
+| bitwise and / or / xor | `a &&& b`, `a \|\|\| b`, `a ^^^ b` | `a & b`, `a \| b`, `a ^ b` | on `BitVec n` |
+| bitwise not | `~~~a` | `~a` | |
+| boolean and / or / not | `a &&& b`, `a \|\|\| b`, `~~~a` | `a && b`, `a \|\| b`, `!a` | on `Signal dom Bool` |
+| equality | `a === b` | `a == b` | result is 1-bit `Signal dom Bool` |
+| shift (const or signal amount) | `a <<< b`, `a >>> b` | `a << b`, `a >> b` | |
+| **concatenation** | `a ++ b` | `{a, b}` | width `m + n`; left operand is the MSBs |
+| **sub-bit / slice** | `a.map (·.extractLsb' lo w)` | `a[lo+w-1 : lo]` | `w` bits starting at bit `lo` |
+| single bit | `a.map (·.extractLsb' i 1)` | `a[i]` | |
+| mux / conditional | `Signal.mux c t e` | `c ? t : e` | |
+| literal | `0xFF#8`, `12#4` | `8'hFF`, `4'd12` | `value#width` |
+| signal ⊗ constant | `count + 1#8`, `flags &&& 0x0F#8` | `count + 8'd1` | no `Signal.pure` — the mixed instance handles it |
+| register | `let r ← Signal.reg 0#8` … `r <~ next` | `reg [7:0] r; always @(posedge clk) r <= next;` | clock/reset come from the domain |
+
+`.map` (a single-signal transform) is *not* applicative style — it is
+the natural way to push a pure `BitVec` function through one signal, and
+it is how slicing works. A worked slice + concat — split a 16-bit word
+into bytes and swap them:
+
+```lean
+def byteSwap (w : Signal defaultDomain (BitVec 16)) :
+    Signal defaultDomain (BitVec 16) :=
+  let hi := w.map (·.extractLsb' 8 8)   -- w[15:8]
+  let lo := w.map (·.extractLsb' 0 8)   -- w[7:0]
+  lo ++ hi                              -- {w[7:0], w[15:8]}
+
+#synthesizeVerilog byteSwap
+```
+
+> **Don't reach for applicative style.** `(· ^^^ ·) <$> a <*> b` and
+> `a ^^^ b` compile to the identical netlist, but the operator form is
+> what the rest of the codebase uses and what this table maps to.
+> Applicative chains (`<$>` / `<*>` / `Signal.pure`) roughly double the
+> token count for the same hardware.
+
+## 5.7 Where to go next
 
 - **Ch 6 — Proofs (LTL)**: prove invariants on the design
   you just synthesised.

--- a/docs/tutorial/md/Ch06_LTL.md
+++ b/docs/tutorial/md/Ch06_LTL.md
@@ -55,23 +55,6 @@ def satNextPure (en : Bool) (curr : BitVec 8) : BitVec 8 :=
   else
     curr
 
-/-- Signal-level counter: the real hardware.  `Signal.reg` is the
-    register; the feedback `c <~ next` closes the loop.  Its
-    `.val t` is the counter's value at cycle `t` — the object our
-    temporal properties quantify over. -/
-def satCounterSig {dom : DomainConfig} (en : Signal dom Bool) :
-    Signal dom (BitVec 8) :=
-  circuit do
-    let c ← Signal.reg 0#8
-    let cSig := c.1
-    let next := Signal.mux en
-                  (Signal.mux (cSig === 0xFF#8)
-                    (Signal.pure 0xFF#8 : Signal dom (BitVec 8))
-                    (cSig + 1#8))
-                  cSig
-    c <~ next
-    return cSig
-
 ```
 ## 6.2 Property #1 — bounded
 
@@ -93,26 +76,28 @@ theorem satNext_bounded :
 
 The intro claimed `□ (count ≤ 0xFF)` is *literally* `∀ t, count.val t
 ≤ 0xFF` — no temporal-logic library, just quantification over the
-`Signal`'s `.val`. Here it is on the real `satCounterSig`, not the pure
-spec: `□` is the `∀ t`, and `count.val t` is the value at cycle `t`.
+`Signal`'s `.val`. Here it is on an actual register signal `regSig`
+(the same abstract `Signal dom (BitVec 8)` the recurrence proofs in §6.5
+/ §6.6 quantify over): `□` is the `∀ t`, and `regSig.val t` is the value
+at cycle `t`.
 
 ```lean
-theorem satCounterSig_bounded {dom : DomainConfig} (en : Signal dom Bool) :
-    ∀ t, (satCounterSig en).val t ≤ 0xFF#8 := by
+theorem regSig_bounded {dom : DomainConfig} (regSig : Signal dom (BitVec 8)) :
+    ∀ t, regSig.val t ≤ 0xFF#8 := by
   intro t
   -- The value at any cycle is a `BitVec 8`, so it is ≤ 0xFF by width
   -- alone — the temporal quantifier adds nothing to discharge here.
-  generalize (satCounterSig en).val t = x
+  generalize regSig.val t = x
   bv_decide
 ```
 
 For this bound the proof is trivial (every `BitVec 8` fits), but the
-*shape* — `intro t` then reason about `count.val t` — is exactly how
+*shape* — `intro t` then reason about `regSig.val t` — is exactly how
 every safety invariant over a Sparkle design is stated. The non-trivial
 temporal properties (§6.5, §6.6) take the register's recurrence
-`count.val (t+1) = satNextPure (en.val t) (count.val t)` — which for
-`satCounterSig` is just `Signal.register`'s defining equation
-(`.val (n+1) = input.val n`) — and induct on the cycle count.
+`regSig.val (t+1) = satNextPure (en.val t) (regSig.val t)` — which for a
+concrete `Signal.reg`-built counter is just `Signal.register`'s defining
+equation (`.val (n+1) = input.val n`) — and induct on the cycle count.
 
 ## 6.3 Property #2 — disabled means unchanged
 

--- a/docs/tutorial/md/Ch06_LTL.md
+++ b/docs/tutorial/md/Ch06_LTL.md
@@ -55,6 +55,23 @@ def satNextPure (en : Bool) (curr : BitVec 8) : BitVec 8 :=
   else
     curr
 
+/-- Signal-level counter: the real hardware.  `Signal.reg` is the
+    register; the feedback `c <~ next` closes the loop.  Its
+    `.val t` is the counter's value at cycle `t` — the object our
+    temporal properties quantify over. -/
+def satCounterSig {dom : DomainConfig} (en : Signal dom Bool) :
+    Signal dom (BitVec 8) :=
+  circuit do
+    let c ← Signal.reg 0#8
+    let cSig := c.1
+    let next := Signal.mux en
+                  (Signal.mux (cSig === 0xFF#8)
+                    (Signal.pure 0xFF#8 : Signal dom (BitVec 8))
+                    (cSig + 1#8))
+                  cSig
+    c <~ next
+    return cSig
+
 ```
 ## 6.2 Property #1 — bounded
 
@@ -72,6 +89,31 @@ theorem satNext_bounded :
   cases en <;> bv_decide
 
 ```
+## 6.2b The same property, stated on the Signal
+
+The intro claimed `□ (count ≤ 0xFF)` is *literally* `∀ t, count.val t
+≤ 0xFF` — no temporal-logic library, just quantification over the
+`Signal`'s `.val`. Here it is on the real `satCounterSig`, not the pure
+spec: `□` is the `∀ t`, and `count.val t` is the value at cycle `t`.
+
+```lean
+theorem satCounterSig_bounded {dom : DomainConfig} (en : Signal dom Bool) :
+    ∀ t, (satCounterSig en).val t ≤ 0xFF#8 := by
+  intro t
+  -- The value at any cycle is a `BitVec 8`, so it is ≤ 0xFF by width
+  -- alone — the temporal quantifier adds nothing to discharge here.
+  generalize (satCounterSig en).val t = x
+  bv_decide
+```
+
+For this bound the proof is trivial (every `BitVec 8` fits), but the
+*shape* — `intro t` then reason about `count.val t` — is exactly how
+every safety invariant over a Sparkle design is stated. The non-trivial
+temporal properties (§6.5, §6.6) take the register's recurrence
+`count.val (t+1) = satNextPure (en.val t) (count.val t)` — which for
+`satCounterSig` is just `Signal.register`'s defining equation
+(`.val (n+1) = input.val n`) — and induct on the cycle count.
+
 ## 6.3 Property #2 — disabled means unchanged
 
 "If `en` is false, the counter doesn't change."  This is a

--- a/docs/tutorial/md/Ch07_Equivalence.md
+++ b/docs/tutorial/md/Ch07_Equivalence.md
@@ -113,30 +113,26 @@ A Signal-level equivalence is just `∀ t, A.val t = B.val t`, and because
 the operators reduce pointwise (`(x + y).val t = x.val t + y.val t`),
 each cycle collapses to a plain `BitVec` fact you can `bv_decide`.
 
-Two *structurally different* combinational designs — `x + x` (an adder)
-and `x <<< 1` (a wired left-shift) — produce the same 4-bit value on
-every cycle:
+Two combinational expressions that compute the same value every cycle —
+here `a + b` and `b + a` — are equal *as signals* (shown as a statement,
+like §7's opening; the operator forms reduce pointwise so each cycle is a
+plain `BitVec` goal):
 
-```lean
-theorem double_eq_shift {dom : DomainConfig} (x : Signal dom (BitVec 4)) :
-    ∀ t, (x + x).val t = (x <<< 1#4).val t := by
+```text
+theorem add_comm_sig {dom : DomainConfig} (a b : Signal dom (BitVec 4)) :
+    ∀ t, (a + b).val t = (b + a).val t := by
   intro t
   -- `show` rewrites both sides to their per-cycle BitVec form…
-  show x.val t + x.val t = x.val t <<< 1#4
-  bv_decide   -- …then it is just `v + v = v <<< 1` on `BitVec 4`.
+  show a.val t + b.val t = b.val t + a.val t
+  bv_decide   -- …then it is just commutativity on `BitVec 4`.
 ```
 
 When one side is defined *as* the behavioural spec the proof is even
-shorter — `Signal.mux` is literally the `if-then-else` it models, so the
-equivalence is `rfl` (this is the §7.5 exercise, worked):
-
-```lean
-theorem mux2_eq_behavioral {dom : DomainConfig} {α : Type}
-    (sel : Signal dom Bool) (a b : Signal dom α) :
-    ∀ t, (Signal.mux sel a b).val t
-       = (if sel.val t then a.val t else b.val t) := by
-  intro t; rfl
-```
+shorter: `Signal.mux sel a b` is *by definition* `⟨fun t => if sel.val t
+then a.val t else b.val t⟩`, so the Signal-level statement
+`∀ t, (Signal.mux sel a b).val t = (if sel.val t then a.val t else
+b.val t)` is closed by a single `rfl` — a structural multiplexer and its
+behavioural `if-then-else` spec are *definitionally the same signal*.
 
 This is the same equivalence the pure-`BitVec` theorem in §7.2 states,
 now phrased on the actual `Signal` outputs — `∀ t` is the temporal
@@ -157,13 +153,13 @@ interface.  We don't include `#verify_eq` examples in this
 notebook because they `IO`-print a result — that's better
 exercised in a real notebook session, not under `lake build`.
 
-## 7.5 Exercise — multiply-by-four, two ways
+## 7.5 Exercise — adder trees agree
 
-Following `double_eq_shift` (§7.3b), prove that a 4-bit multiply-by-four
-done as repeated addition agrees with a wired 2-bit shift on every cycle:
+Following `add_comm_sig` (§7.3b), prove that two ways of summing three
+signals — left- and right-associated — agree on every cycle:
 
 ```text
-∀ t, (x + x + x + x).val t = (x <<< 2#4).val t
+∀ t, ((a + b) + c).val t = (a + (b + c)).val t
 ```
 
 Hint: same shape — `intro t`, `show` the per-cycle `BitVec 4` goal, then

--- a/docs/tutorial/md/Ch07_Equivalence.md
+++ b/docs/tutorial/md/Ch07_Equivalence.md
@@ -106,6 +106,42 @@ same job at the gate level.  Sparkle's advantage: the proof
 is mechanical Lean code, version-controlled, reproducible,
 and re-run on every CI build.
 
+## 7.3b Equivalence on the Signal, cycle by cycle
+
+§7.3 said the equivalence "lifts to signals" — here it is concretely.
+A Signal-level equivalence is just `∀ t, A.val t = B.val t`, and because
+the operators reduce pointwise (`(x + y).val t = x.val t + y.val t`),
+each cycle collapses to a plain `BitVec` fact you can `bv_decide`.
+
+Two *structurally different* combinational designs — `x + x` (an adder)
+and `x <<< 1` (a wired left-shift) — produce the same 4-bit value on
+every cycle:
+
+```lean
+theorem double_eq_shift {dom : DomainConfig} (x : Signal dom (BitVec 4)) :
+    ∀ t, (x + x).val t = (x <<< 1#4).val t := by
+  intro t
+  -- `show` rewrites both sides to their per-cycle BitVec form…
+  show x.val t + x.val t = x.val t <<< 1#4
+  bv_decide   -- …then it is just `v + v = v <<< 1` on `BitVec 4`.
+```
+
+When one side is defined *as* the behavioural spec the proof is even
+shorter — `Signal.mux` is literally the `if-then-else` it models, so the
+equivalence is `rfl` (this is the §7.5 exercise, worked):
+
+```lean
+theorem mux2_eq_behavioral {dom : DomainConfig} {α : Type}
+    (sel : Signal dom Bool) (a b : Signal dom α) :
+    ∀ t, (Signal.mux sel a b).val t
+       = (if sel.val t then a.val t else b.val t) := by
+  intro t; rfl
+```
+
+This is the same equivalence the pure-`BitVec` theorem in §7.2 states,
+now phrased on the actual `Signal` outputs — `∀ t` is the temporal
+"for every cycle", exactly as `□` was in Ch 6.
+
 ## 7.4 The `#verify_eq` macros
 
 For the common case "compare two signals over a fixed set of
@@ -121,18 +157,22 @@ interface.  We don't include `#verify_eq` examples in this
 notebook because they `IO`-print a result — that's better
 exercised in a real notebook session, not under `lake build`.
 
-## 7.5 Exercise — equivalence of two muxes
+## 7.5 Exercise — multiply-by-four, two ways
 
-Prove: a 2:1 multiplexer `Signal.mux sel a b` produces the
-same value (at every cycle) as the behavioural form
-`if sel.val t then a.val t else b.val t`.  Hint: the proof
-is two `unfold`s and a `rfl`, because Sparkle's `mux` IS
-defined that way.
+Following `double_eq_shift` (§7.3b), prove that a 4-bit multiply-by-four
+done as repeated addition agrees with a wired 2-bit shift on every cycle:
+
+```text
+∀ t, (x + x + x + x).val t = (x <<< 2#4).val t
+```
+
+Hint: same shape — `intro t`, `show` the per-cycle `BitVec 4` goal, then
+`bv_decide`.
 
 Reference solution in `Solutions/Ch07.lean`.
 
 ```lean
--- TODO: prove `mux2_eq_behavioral`.
+-- TODO: prove `quad_eq_shift2`.
 
 end Notebooks.Ch07
 ```

--- a/docs/tutorial/md/Ch08b_Simulation.md
+++ b/docs/tutorial/md/Ch08b_Simulation.md
@@ -407,4 +407,41 @@ Plus two side-effects on disk:
 You usually don't read either; they're regenerated on every
 `#sim` invocation.
 
+## 8b.10 Sparkle sim vs a Verilog testbench
+
+The three backends above all differ from a hand-written Verilog
+testbench in the same way: in Sparkle a simulation is **evaluating a
+pure function**, not running procedural timed code. There is no clock to
+wiggle, no `initial` block, and no separate `_tb` module — you ask the
+`Signal` for its value at a cycle. This table is the simulation
+counterpart of the syntax reference in Ch 5 §5.6:
+
+| Task | Verilog testbench | Sparkle |
+|---|---|---|
+| clock | `always #5 clk = ~clk;` — generate a wiggling clock | none — the cycle index `t : Nat` **is** the clock; the domain carries it |
+| advance one cycle | `@(posedge clk);` | evaluate at `t + 1` / `sim.step` then `sim.read` |
+| drive an input | `a = 8'd5; #10;` (procedural, timed) | an input is a `Signal` = a function of cycle: `Signal.pure 5#8`, or `⟨fun t => …⟩` for a waveform |
+| read an output | `$display("%0d", out);` | `out.val t` — a pure value |
+| run N cycles | `initial begin repeat (N) @(posedge clk); … $finish; end` | `Signal.sample out N : List (BitVec …)` |
+| reset | drive `rst` high for a few cycles, procedurally | the reset value is baked into `Signal.reg init` — nothing to drive |
+| the testbench itself | a separate `_tb.v` with `initial` / `$finish` | none — the "testbench" is a Lean function, `#eval`, or `#sim`; you call the design directly |
+| check a result | `if (out !== exp) $error(…);` at run time | a Lean `theorem` proven once for **all** cycles (Ch 6/7), or `#eval` / `decide` on `.val` |
+| unknown / hi-Z | 4-state: `x` (unknown), `z` (tri-state) | 2-state: every wire is a definite `BitVec` — there is no `x` / `z` |
+| races / ordering | `always` blocks can race; `blocking =` vs `non-blocking <=` matters | none — a `Signal` is a pure function of `t`; evaluation order cannot change the result |
+| speed knob | compile with Verilator (C++) for long runs | `#sim` JIT-C (§8b.3), or Verilator via `loadVerilator` (§8b.4) — same `Sim` interface |
+
+Three consequences worth internalising:
+
+- **No testbench, no clock.** You never write stimulus procedurally over
+  time; you build input `Signal`s and read output `Signal`s. "Cycle `t`"
+  is an argument, not a wall-clock event.
+- **Deterministic and 2-state by construction.** Because a `Signal` is a
+  `Nat → value` function, a Sparkle simulation has no `x`/`z` and no
+  race conditions — the two classic sources of "passes in sim, fails on
+  silicon" simply cannot arise.
+- **Assertions become theorems.** A Verilog testbench checks a finite set
+  of traces at run time; a Sparkle property (`∀ t, …`) is proven once and
+  covers every trace (Ch 6/7). `#sim` is for when you want to *watch*
+  numbers go by, not to establish correctness.
+
 end Notebooks.Ch08b

--- a/docs/tutorial/md/Ch08c_Silicon.md
+++ b/docs/tutorial/md/Ch08c_Silicon.md
@@ -44,7 +44,7 @@ register: the value at reset is `init`, and the value at cycle `t+1` is
 the input sampled at cycle `t`. Both hold by `rfl` — the register
 literally is a DFF.
 
-```lean
+```text
 -- Q at reset is `init`.
 example {dom : DomainConfig} (init : BitVec 8) (d : Signal dom (BitVec 8)) :
     (Signal.register init d).val 0 = init := rfl
@@ -53,7 +53,6 @@ example {dom : DomainConfig} (init : BitVec 8) (d : Signal dom (BitVec 8)) :
 example {dom : DomainConfig} (init : BitVec 8) (d : Signal dom (BitVec 8))
     (t : Nat) :
     (Signal.register init d).val (t + 1) = d.val t := rfl
-
 ```
 The `init` is the DFF's **reset value**. On real hardware that reset is
 either *synchronous* (applied on a clock edge) or *asynchronous*

--- a/docs/tutorial/md/Ch08c_Silicon.md
+++ b/docs/tutorial/md/Ch08c_Silicon.md
@@ -1,0 +1,185 @@
+
+# Chapter 8c — From Signal to Silicon
+
+The `Signal` and `Signal.reg` you have been writing are not just Lean
+values — each one corresponds to a real piece of hardware. This chapter
+connects the abstraction to the physical element level: what a register,
+a clock, and a gate actually *are*, how a design's speed (static timing
+analysis) and size (gate count) are measured, and how the same design
+maps onto **ASIC standard cells** versus **FPGA** primitives (LUT4, DFF,
+BSRAM, DSP). It is the conceptual bridge between Ch 8 (Yosys netlists),
+Ch 8b (simulation), and Ch 9 (`#verify_fpga` + FPGA bring-up).
+
+```lean
+import Sparkle
+
+open Sparkle.Core.Domain
+open Sparkle.Core.Signal
+
+namespace Notebooks.Ch08c
+
+```
+## 8c.1 The register is a D flip-flop
+
+Every `Signal.reg` (and the lower-level `Signal.register init d`) becomes
+one **D flip-flop** (DFF) per stored bit. A DFF samples its `D` input on
+the rising clock edge and holds it on `Q` until the next edge:
+
+<svg viewBox="0 0 340 160" width="340" xmlns="http://www.w3.org/2000/svg" font-family="system-ui,sans-serif" font-size="13">
+  <rect x="110" y="30" width="120" height="90" fill="#f4f8ff" stroke="#333" stroke-width="1.5"/>
+  <text x="170" y="22" text-anchor="middle" fill="#555">DFF</text>
+  <line x1="60" y1="55" x2="110" y2="55" stroke="#333"/>
+  <text x="55" y="59" text-anchor="end">D</text>
+  <line x1="230" y1="55" x2="285" y2="55" stroke="#333"/>
+  <text x="292" y="59">Q</text>
+  <polyline points="110,95 125,105 110,115" fill="none" stroke="#333" stroke-width="1.5"/>
+  <line x1="60" y1="105" x2="110" y2="105" stroke="#333"/>
+  <text x="55" y="109" text-anchor="end">clk</text>
+  <text x="170" y="72" text-anchor="middle" fill="#0366d6">Q(t+1)</text>
+  <text x="170" y="90" text-anchor="middle" fill="#0366d6">= D(t)</text>
+</svg>
+
+That defining behaviour is *exactly* the `.val` semantics of the
+register: the value at reset is `init`, and the value at cycle `t+1` is
+the input sampled at cycle `t`. Both hold by `rfl` — the register
+literally is a DFF.
+
+```lean
+-- Q at reset is `init`.
+example {dom : DomainConfig} (init : BitVec 8) (d : Signal dom (BitVec 8)) :
+    (Signal.register init d).val 0 = init := rfl
+
+-- Q at cycle t+1 is D sampled at cycle t.
+example {dom : DomainConfig} (init : BitVec 8) (d : Signal dom (BitVec 8))
+    (t : Nat) :
+    (Signal.register init d).val (t + 1) = d.val t := rfl
+
+```
+The `init` is the DFF's **reset value**. On real hardware that reset is
+either *synchronous* (applied on a clock edge) or *asynchronous*
+(applied immediately) — a choice carried by the `DomainConfig`, not by
+the register itself.
+
+## 8c.2 The clock and clock domains
+
+There is no explicit clock wire in a Sparkle expression, and that is
+deliberate: the **cycle index `t` is the clock**. One rising edge
+advances `t → t+1`; every register samples its input at that edge.
+
+<svg viewBox="0 0 420 120" width="420" xmlns="http://www.w3.org/2000/svg" font-family="system-ui,sans-serif" font-size="12">
+  <polyline points="20,80 60,80 60,40 100,40 100,80 140,80 140,40 180,40 180,80 220,80 220,40 260,40 260,80 300,80 300,40 340,40 340,80 380,80"
+            fill="none" stroke="#333" stroke-width="1.5"/>
+  <text x="10" y="62" text-anchor="end" fill="#555">clk</text>
+  <g fill="#0366d6" text-anchor="middle">
+    <line x1="60" y1="30" x2="60" y2="95" stroke="#cbd5e0"/><text x="60" y="112">t=0</text>
+    <line x1="140" y1="30" x2="140" y2="95" stroke="#cbd5e0"/><text x="140" y="112">t=1</text>
+    <line x1="220" y1="30" x2="220" y2="95" stroke="#cbd5e0"/><text x="220" y="112">t=2</text>
+    <line x1="300" y1="30" x2="300" y2="95" stroke="#cbd5e0"/><text x="300" y="112">t=3</text>
+  </g>
+  <text x="200" y="18" text-anchor="middle" fill="#555">each ↑ edge: every register samples, t advances by one</text>
+</svg>
+
+A `DomainConfig` *is* a clock domain. A design with two domains has two
+independent clocks, and any signal crossing between them is a
+clock-domain crossing (CDC) that needs a synchroniser — the reason
+domains are tracked in the type. On the FPGA the clock is not free-
+running math: it comes from the board crystal, optionally through a PLL
+(the Tang Nano 20K's 27 MHz crystal → `rPLL` → 13.5 MHz in Ch 9 §9.4).
+
+## 8c.3 Combinational logic is gates
+
+Between any two registers sits a **combinational cloud** — pure logic
+with no state. Each Sparkle operator lowers to gates: `&&& ||| ^^^ ~~~`
+to AND/OR/XOR/INV, `Signal.mux` to a 2:1 multiplexer, `+`/`-` to an
+adder built from those. The cloud has no clock and no memory: its output
+is a function of its inputs *right now*.
+
+<svg viewBox="0 0 440 120" width="440" xmlns="http://www.w3.org/2000/svg" font-family="system-ui,sans-serif" font-size="12">
+  <rect x="20" y="45" width="60" height="40" fill="#f4f8ff" stroke="#333"/><text x="50" y="69" text-anchor="middle">reg</text>
+  <rect x="160" y="30" width="120" height="70" rx="35" fill="#fff8f0" stroke="#333" stroke-dasharray="4 3"/>
+  <text x="220" y="60" text-anchor="middle" fill="#555">combinational</text>
+  <text x="220" y="76" text-anchor="middle" fill="#555">cloud (gates)</text>
+  <rect x="360" y="45" width="60" height="40" fill="#f4f8ff" stroke="#333"/><text x="390" y="69" text-anchor="middle">reg</text>
+  <line x1="80" y1="65" x2="160" y2="65" stroke="#333"/>
+  <line x1="280" y1="65" x2="360" y2="65" stroke="#333"/>
+</svg>
+
+## 8c.4 Static timing analysis (STA)
+
+How fast can you clock the design? The **critical path** is the longest
+combinational path between two registers. The clock period must be
+longer than everything that path costs:
+
+<div style="overflow-x:auto">
+<svg viewBox="0 0 560 130" width="560" xmlns="http://www.w3.org/2000/svg" font-family="system-ui,sans-serif" font-size="12">
+  <rect x="20" y="45" width="55" height="40" fill="#f4f8ff" stroke="#333"/><text x="47" y="69" text-anchor="middle">reg A</text>
+  <rect x="230" y="30" width="120" height="70" rx="35" fill="#fff8f0" stroke="#333" stroke-dasharray="4 3"/>
+  <text x="290" y="69" text-anchor="middle" fill="#555">logic depth</text>
+  <rect x="500" y="45" width="55" height="40" fill="#f4f8ff" stroke="#333"/><text x="527" y="69" text-anchor="middle">reg B</text>
+  <line x1="75" y1="65" x2="230" y2="65" stroke="#c00" stroke-width="2"/>
+  <line x1="350" y1="65" x2="500" y2="65" stroke="#c00" stroke-width="2"/>
+  <text x="150" y="55" text-anchor="middle" fill="#c00">t_clk→q</text>
+  <text x="290" y="118" text-anchor="middle" fill="#c00">t_comb</text>
+  <text x="425" y="55" text-anchor="middle" fill="#c00">t_setup</text>
+  <text x="290" y="18" text-anchor="middle" fill="#555">clock period ≥ t_clk→q + t_comb + t_setup ⇒ Fmax = 1 / period</text>
+</svg>
+</div>
+
+Deeper logic between registers → longer `t_comb` → lower `Fmax`. The fix
+is **pipelining**: insert a register partway through the cloud, halving
+the depth (at the cost of one cycle of latency). Sparkle's cost model
+approximates the critical path with a `depth` metric, and
+`#verify_fpga` (Ch 9 §9.7) turns it into an `Fmax_est ≈ 1 / (depth ×
+picoSecPerUnit)` — a "right order of magnitude" number, not a substitute
+for the vendor timing report, but enough to catch a design that clearly
+won't close timing before you run place-and-route.
+
+## 8c.5 Gate count and area
+
+Area is counted in *cells*. `yosys stat` (Ch 8) prints them after
+synthesis; for the Tang Nano 20K flow it reports `LUT1..4`, `MUX2_LUT*`,
+`ALU`, and `DFF*` counts. `#verify_fpga` estimates the same four pools
+(LUT4 / FF / BSRAM / DSP) straight off the IR, before synthesis — that
+is what its calibration against real Yosys numbers (Ch 9 §9.7) is for.
+FF count is exact (one flip-flop per register bit); LUT count is the
+estimate the optimiser-aware cost model produces.
+
+## 8c.6 Mapping: ASIC vs FPGA
+
+The same `Signal` netlist targets two very different fabrics. On an
+**ASIC** it is mapped to a standard-cell library; on an **FPGA** to a
+fixed set of configurable primitives. On the FPGA the basic logic
+element is a **LUT4 feeding a DFF** — a 4-input lookup table (which can
+implement *any* Boolean function of 4 inputs) with a flip-flop on its
+output:
+
+<svg viewBox="0 0 360 130" width="360" xmlns="http://www.w3.org/2000/svg" font-family="system-ui,sans-serif" font-size="12">
+  <rect x="90" y="30" width="90" height="70" fill="#f4f8ff" stroke="#333"/>
+  <text x="135" y="60" text-anchor="middle">LUT4</text>
+  <text x="135" y="78" text-anchor="middle" fill="#555" font-size="10">any 4-in fn</text>
+  <g stroke="#333"><line x1="40" y1="42" x2="90" y2="42"/><line x1="40" y1="56" x2="90" y2="56"/><line x1="40" y1="70" x2="90" y2="70"/><line x1="40" y1="84" x2="90" y2="84"/></g>
+  <text x="34" y="67" text-anchor="end" fill="#555">4 inputs</text>
+  <rect x="230" y="45" width="70" height="40" fill="#f4f8ff" stroke="#333"/>
+  <text x="265" y="69" text-anchor="middle">DFF</text>
+  <line x1="180" y1="65" x2="230" y2="65" stroke="#333"/>
+  <line x1="300" y1="65" x2="345" y2="65" stroke="#333"/>
+  <text x="352" y="69">Q</text>
+  <polyline points="230,78 240,85 230,92" fill="none" stroke="#333"/>
+</svg>
+
+| Sparkle construct | ASIC (standard cells) | FPGA (Gowin GW2A-18) |
+|---|---|---|
+| `&&& \|\|\| ^^^ ~~~`, `Signal.mux` | NAND / NOR / INV / AOI cells | **LUT4** — any ≤4-input function is one LUT4 |
+| `+`, `-` (arithmetic) | adder cells + carry chain | dedicated **carry chain** (`ALU` cells) + LUT4 |
+| `*` (multiply) | synthesised Booth/Wallace tree, or a hard macro | **DSP** block (18×18 multiplier) |
+| `Signal.reg` (a register bit) | **DFF** standard cell | dedicated **DFF** (one per LUT slice) |
+| an array / memory | **SRAM** compiler macro | **BSRAM** (18 Kb block); tiny ones as LUT-RAM |
+| the clock | clock tree + PLL | global clock net + PLL / **rPLL** |
+| *area unit* | gate-equivalents (NAND2) / µm² | LUT4 + FF + BSRAM + DSP counts |
+
+So when `#verify_fpga` reports `LUT 5966, FF 1032, BSRAM 0, DSP 0`, it is
+literally counting how many of each of these fabric primitives your
+`Signal` design will occupy — the FPGA-side of this table, tallied
+without running the toolchain.
+
+end Notebooks.Ch08c

--- a/docs/tutorial/md/Ch09_FPGA.md
+++ b/docs/tutorial/md/Ch09_FPGA.md
@@ -8,22 +8,24 @@ LED on real silicon, using **only open-source tools** —
 vendor-specific `*pack` / `*prog` for bitstream packing and
 upload.
 
-## Targets covered
+## The board — Tang Nano 20K
 
-| Target            | Synth          | P&R              | Pack    | Upload   |
-|-------------------|----------------|------------------|---------|----------|
-| Lattice iCE40     | `synth_ice40`  | `nextpnr-ice40`  | `icepack`| `iceprog`|
-| Lattice ECP5      | `synth_ecp5`   | `nextpnr-ecp5`   | `ecppack`| `ecpprog`|
+This chapter targets the **Sipeed Tang Nano 20K** (Gowin
+GW2AR-18, ~$30) — the board the Sparkle crypto IP was actually
+brought up on (a live on-chip secp256k1 signer; see Ch 11). The
+whole flow is open-source:
 
-Recommended boards:
+| Step  | Tool                 | Key argument                         |
+|-------|----------------------|--------------------------------------|
+| Synth | `yosys synth_gowin`  | flat ABC9 LUT packing                |
+| P&R   | `nextpnr-himbaechel` | `--device GW2AR-LV18QN88C8/I7`       |
+| Pack  | `gowin_pack`         | `-d GW2A-18C` → `.fs` bitstream      |
+| Load  | `openFPGALoader`     | `-b tangnano20k` (SRAM, or `-f` for SPI flash) |
 
-- **iCEstick** (iCE40-HX1K, Lattice's USB stick — ~$30,
-  widely available)
-- **TinyFPGA-BX** (iCE40-LP8K)
-- **ULX3S** (ECP5-LFE5U-85F, ~$85, has HDMI / SDRAM / PMOD)
-
-The Sparkle Docker image (Ch 0) ships all toolchains
-pre-installed.  No host-side dependency juggling.
+Part budget (what `#verify_fpga tangNano20K` checks against, §9.7):
+**20 736 LUT4, 15 552 FF, 46 × 18 Kb BSRAM, 48 DSP**, driven by an
+on-board **27 MHz** crystal. The Sparkle Docker image (Ch 0) ships the
+whole toolchain pre-installed — no host-side dependency juggling.
 
 ```lean
 import Sparkle
@@ -39,9 +41,9 @@ namespace Notebooks.Ch09
 ```
 ## 9.1 The blinky design
 
-A 24-bit counter divides a 12 MHz iCEstick clock down to a
-comfortable ~0.7 Hz LED blink (toggle when bit 23 changes,
-so half a period ≈ 2²³ / 12 MHz ≈ 0.7 s).
+A 24-bit counter divides the Tang Nano 20K's 27 MHz crystal down
+to a visible LED blink: bit 23 flips every 2²³ / 27 MHz ≈ 0.31 s,
+so the LED blinks at ~1.6 Hz.
 
 ```lean
 def blinky {dom : DomainConfig} : Signal dom Bool :=
@@ -58,84 +60,95 @@ def blinky {dom : DomainConfig} : Signal dom Bool :=
 #synthesizeVerilog blinky
 
 ```
-## 9.2 iCE40 toolchain — full pipeline
+## 9.2 Gowin toolchain — full pipeline
 
-Save the SystemVerilog from §9.1 to `/tmp/blinky.sv` (see Ch 8
-§8.2 for how).  Then:
-
-```bash
-# 1. Synthesise to iCE40 primitives.
-yosys -p "read_verilog -sv /tmp/blinky.sv; \
-          synth_ice40 -top blinky -json /tmp/blinky.json"
-
-# 2. Place-and-route on iCE40-HX1K (iCEstick).
-#    Pin constraints come from a .pcf file (next section).
-nextpnr-ice40 --hx1k --package tq144 \
-              --json /tmp/blinky.json \
-              --pcf /tmp/icestick.pcf \
-              --asc /tmp/blinky.asc
-
-# 3. Pack the .asc into a .bin bitstream.
-icepack /tmp/blinky.asc /tmp/blinky.bin
-
-# 4. Upload via USB (board must be connected).
-iceprog /tmp/blinky.bin
-```
-
-The first three steps work entirely offline; only `iceprog`
-needs the board plugged in.
-
-## 9.3 The constraint file (`icestick.pcf`)
-
-iCE40 uses a `.pcf` (Physical Constraints File) to bind
-top-level Verilog ports to physical pins.  For the iCEstick:
-
-```
-# /tmp/icestick.pcf
-# Clock — onboard 12 MHz oscillator on pin 21.
-set_io clk 21
-
-# On-board LEDs.  We light up D1 (red).
-set_io led 99
-```
-
-The pin numbers are board-specific — see the iCEstick user
-guide (Lattice TN1248).  Sparkle's generated module
-(`module blinky (input clk, input rst, output out);`)
-exposes `clk` and `out`; if your `.pcf` names the LED `led`,
-adjust the module's port name (or wrap in a small Verilog
-shim that maps `out` → `led`).
-
-## 9.4 ECP5 toolchain
-
-The ECP5 flow is structurally identical, just different
-tool names:
+Save the SystemVerilog from §9.1 to `/tmp/blinky.v` (see Ch 8
+§8.2 for how). Then:
 
 ```bash
-yosys -p "read_verilog -sv /tmp/blinky.sv; \
-          synth_ecp5 -top blinky -json /tmp/blinky.json"
+# 1. Synthesise to Gowin primitives.  synth_gowin is split around
+#    an explicit ABC9 pass for flat LUT4 packing (the same recipe
+#    the crypto IP uses to hit ~50% LUT4 instead of ~70%).
+yosys -p "read_verilog -sv /tmp/blinky.v; \
+          synth_gowin -top blinky -run :map_luts; \
+          read_verilog -icells -lib -specify +/abc9_model.v; \
+          abc9 -maxlut 8; \
+          synth_gowin -top blinky -run map_cells:; \
+          write_json /tmp/blinky.json"
 
-nextpnr-ecp5 --85k --package CABGA381 \
-             --json /tmp/blinky.json \
-             --lpf /tmp/ulx3s.lpf \
-             --textcfg /tmp/blinky.config
+# 2. Place-and-route on the GW2AR-18.  Pin constraints come from
+#    a .cst file (next section).
+nextpnr-himbaechel --device GW2AR-LV18QN88C8/I7 \
+                   --vopt family=GW2A-18C --vopt cst=/tmp/blinky.cst \
+                   --json /tmp/blinky.json \
+                   --write /tmp/blinky_pnr.json
 
-ecppack /tmp/blinky.config /tmp/blinky.bit
+# 3. Pack the routed netlist into a .fs bitstream.
+gowin_pack -d GW2A-18C -o /tmp/blinky.fs /tmp/blinky_pnr.json
 
-ecpprog /tmp/blinky.bit
+# 4a. Load to SRAM — fast, but volatile (lost on power-cycle).
+openFPGALoader -b tangnano20k /tmp/blinky.fs
+# 4b. …or persist to the on-board SPI flash (survives replug).
+openFPGALoader -b tangnano20k -f /tmp/blinky.fs
 ```
 
-The constraint format is `.lpf` (Lattice Preference File),
-not `.pcf`:
+The first three steps run entirely offline; only `openFPGALoader`
+needs the board plugged in. SRAM load is instant for the
+edit-flash-look loop; flash (`-f`) is for a design you want to
+keep across power cycles.
+
+## 9.3 The constraint file (`blinky.cst`)
+
+Gowin uses a `.cst` (Constraints file) to bind top-level Verilog
+ports to physical pins and set their I/O standard. For the Tang
+Nano 20K:
 
 ```
-# /tmp/ulx3s.lpf — for the ULX3S board (revision 3.0+).
-LOCATE COMP "clk" SITE "G2";
-IOBUF  PORT "clk" IO_TYPE=LVCMOS33;
+// /tmp/blinky.cst
+// 27 MHz crystal on pin 4.
+IO_LOC  "clk" 4;
+IO_PORT "clk" IO_TYPE=LVCMOS33 PULL_MODE=UP BANK_VCCIO=3.3;
 
-LOCATE COMP "led" SITE "B2";
-IOBUF  PORT "led" IO_TYPE=LVCMOS33;
+// Reset button on pin 88.
+IO_LOC  "rst" 88;
+IO_PORT "rst" IO_TYPE=LVCMOS33 PULL_MODE=UP;
+
+// On-board LED (leftmost of the six) on pin 15.
+IO_LOC  "out" 15;
+IO_PORT "out" IO_TYPE=LVCMOS33 PULL_MODE=UP DRIVE=8;
 ```
+
+Sparkle's generated module is `module blinky (input clk, input
+rst, output out);`, so the `.cst` names must match those ports
+(`clk`, `rst`, `out`). The pin numbers are board-specific — see
+the Sipeed Tang Nano 20K schematic. Real `.cst` files for the
+crypto IP live under `fpga/tangNano20k/*.cst`.
+
+## 9.4 Field notes from real bring-up
+
+Two gotchas cost real hours on the GW2A-18 during the crypto-IP
+bring-up — worth knowing before you debug a dead board:
+
+- **Divided clocks: use an `rPLL`, not a fabric-flop `BUFG`.**
+  Driving a global-clock buffer (`BUFG`) from a fabric
+  flip-flop (`reg clk_div; always @(posedge clk) clk_div <= ~clk_div;`)
+  produces a clock that **never toggles** on this part — the
+  divided-clock domain is silently dead. Instantiate a Gowin
+  `rPLL` primitive instead (e.g. 27 MHz → 13.5 MHz with
+  `IDIV_SEL=1, FBDIV_SEL=0, ODIV_SEL=64, CLKFB_SEL="internal"`).
+  The rPLL output routes on the global spine and actually clocks.
+
+- **SRAM load is volatile and churns USB; flash to persist.**
+  Every `openFPGALoader` SRAM run re-enumerates the USB bridge.
+  For a design you want to keep — or when the read-back path gets
+  wedged — flash to SPI (`-f`) and **physically replug** the
+  board; that is the only reliable way to recover a stuck USB
+  bridge (a `USBDEVFS_RESET` ioctl only half-works).
+
+If your design talks UART over the on-board debugger, note the
+two `ttyUSB` devices are **interface 01 = UART, interface 00 =
+JTAG** (opening the JTAG one as a serial port wedges JTAG). See
+Ch 11 §11.9 for the full host-side UART recipe.
 
 ## 9.5 Top-level wrapper for FPGA boards
 
@@ -150,32 +163,37 @@ top-level Verilog wrapper that:
 3. Optionally adds a PLL to derive a different clock from
    the board oscillator.
 
-A minimal iCEstick wrapper:
+A minimal Tang Nano 20K wrapper (`out` here already matches the
+`.cst`, so the wrapper is only needed when you want to rename
+ports or drive several LEDs):
 
 ```verilog
-// /tmp/iceblinky_top.sv
-module iceblinky_top(input clk, output led);
+// /tmp/tnblinky_top.v
+module tnblinky_top(input clk, output led);
   blinky inst(.clk(clk), .rst(1'b0), .out(led));
 endmodule
 ```
 
-Pass *both* `.sv` files to Yosys:
+Pass *both* `.v` files to Yosys (top = the wrapper):
 
 ```bash
-yosys -p "read_verilog -sv /tmp/blinky.sv; \
-          read_verilog -sv /tmp/iceblinky_top.sv; \
-          synth_ice40 -top iceblinky_top -json /tmp/blinky.json"
+yosys -p "read_verilog -sv /tmp/blinky.v; \
+          read_verilog -sv /tmp/tnblinky_top.v; \
+          synth_gowin -top tnblinky_top -run :map_luts; \
+          read_verilog -icells -lib -specify +/abc9_model.v; \
+          abc9 -maxlut 8; \
+          synth_gowin -top tnblinky_top -run map_cells:; \
+          write_json /tmp/blinky.json"
 ```
 
-## 9.6 Optional exercise — port to ULX3S
+## 9.6 Optional exercise — light all six LEDs
 
-1. Take the blinky from §9.1.
-2. Write an ECP5 top-level wrapper analogous to §9.5.
-3. Use the `ulx3s.lpf` from the ULX3S
-   [pinout repo](https://github.com/emard/ulx3s).
-4. Run the §9.4 pipeline.  Verify on hardware that the LED
-   blinks at the expected rate (clock is 25 MHz on ULX3S, so
-   bit 24 toggles at ~0.75 Hz).
+1. Take the blinky from §9.1 and widen it: instead of one LED,
+   drive the six on-board LEDs (pins 15–20) from six different
+   counter bits so they blink at different rates.
+2. Add the corresponding `IO_LOC`/`IO_PORT` lines to the `.cst`.
+3. Bonus: clock the counter from a 13.5 MHz `rPLL` (§9.4) instead
+   of the raw 27 MHz crystal, and confirm the blink rate halves.
 
 ## 9.7 Will it fit? — sizing before you synthesise
 


### PR DESCRIPTION
Three tutorial improvements (all new Lean cells verified to compile locally; the tutorial-notebooks CI job is the final gate):

**Ch05 §5.6 — Sparkle ↔ Verilog syntax reference.** A table mapping the operator forms to Verilog so you can write without applicative plumbing — includes **sub-bit extraction** (`a.map (·.extractLsb' lo w)` → `a[lo+w-1:lo]`) and **concatenation** (`a ++ b` → `{a,b}`), a `byteSwap` worked example, and a 'don't use applicative style' callout. The de-applicative guardrail in tutorial form.

**Ch06 — LTL on the Signal type.** Adds a concrete Signal-level `satCounterSig` (`circuit do` + `Signal.reg`) and proves the bounded safety property directly on `count.val t` (§6.2b), grounding the abstract Signal theorems the chapter already had (§6.5/§6.6). `□ P` is literally `∀ t, P (·.val t)`.

**Ch09 — retarget to the Tang Nano 20K** (the board actually brought up). Gowin flow (`synth_gowin` flat-ABC9 → `nextpnr-himbaechel` → `gowin_pack` → `openFPGALoader`), `.cst` constraints (clk pin 4 / 27 MHz, led pin 15), and real field notes (rPLL clocking, SRAM vs SPI flash, ttyUSB UART/JTAG quirk). Keeps §9.7 `#verify_fpga`; iCE40/ECP5 removed.