### PR TITLE
fix(compiler): eliminate E = I·(D+1) sub-module instance duplication …

### DIFF
--- a/Sparkle/Compiler/Elab.lean
+++ b/Sparkle/Compiler/Elab.lean
@@ -608,6 +608,32 @@ private initialize sparkleSubModuleCache :
 private initialize sparkleSubInstanceOutputs :
     IO.Ref (Std.HashMap (UInt64 × String) String) ← IO.mkRef {}
 
+/-- Idempotency cache for SINGLE-output sub-module instances
+    (Issue #107).  The synth elaborator walks a `circuit do` body
+    once per register next-state leaf plus once for the output
+    leaf; a `let t := toggle en` binding is re-translated on every
+    pass because named translations bypass the structural
+    `exprCache` (see `cacheable` in `translateExprToWire`), so
+    each pass emitted a fresh instance — E = I · (D + 1) instead
+    of I.  The multi-output path has its own guard keyed on
+    `sparkleSubInstanceOutputs`; this covers the scalar path.
+
+    Key: `parent module name # child module name # port
+    connections (canonical wire names)`.  The connection wires
+    make the key fine enough to keep `toggle e0` / `toggle e1`
+    distinct (keying on name + arity alone would FOLD distinct
+    instances — a miscompile, not a cleanup).  The parent module
+    name scopes the cached output wire to the module that
+    actually declared it.  Folding same-key instances is sound:
+    two structurally identical calls denote the same signal in
+    Sparkle's pure semantics, stateful or not (same module, same
+    inputs, same reset ⇒ same state trajectory).
+
+    Value: the instance's output wire.  Cleared at depth 0 with
+    the other per-synth caches. -/
+private initialize sparkleSingleOutInstanceCache :
+    IO.Ref (Std.HashMap String String) ← IO.mkRef {}
+
 /-- Type-of-Expr cache.  `Lean.Meta.inferType` is the dominant
     cost in handleTupleProjections / handleApplicative / handleMux
     (typeclass-instance search fires per call); the same `e` is
@@ -1595,8 +1621,35 @@ mutual
         pure false
 
       if isHW then
-        -- Hardware let: translate value to wire
-        let valueWire ← translateExprToWire value name.toString (isTopLevel := false) (isNamed := true)
+        -- Hardware let: translate value to wire.
+        --
+        -- Issue #107 (multi-pass variant): the elaborator re-walks
+        -- the circuit body once per register next-state leaf, and
+        -- `isNamed := true` bypasses the structural `exprCache` in
+        -- both directions — so every pass re-materialised each
+        -- let's whole value cone under fresh names (`_gen_x`,
+        -- `_gen_x_1`, …), and anything keyed on those wires (the
+        -- sub-module instance dedupe in particular) could never
+        -- fold across passes.  Consult the cache explicitly before
+        -- translating and populate it after: a later pass that
+        -- reaches a structurally identical `let` value reuses the
+        -- first pass's wire, which makes the downstream wire names
+        -- pass-stable by induction down the let chain.
+        let cacheRef? := (← CompilerM.getCompilerState).exprCache
+        let cachedW? ←
+          match cacheRef? with
+          | some ref => CompilerM.liftMetaM do
+              let cache ← (ref.get : IO _)
+              return cache.get? ⟨value⟩
+          | none => pure none
+        let valueWire ← match cachedW? with
+          | some w => pure w
+          | none =>
+            let w ← translateExprToWire value name.toString (isTopLevel := false) (isNamed := true)
+            if !value.isFVar then
+              if let some ref := cacheRef? then
+                CompilerM.liftMetaM (ref.modify (·.insert ⟨value⟩ w))
+            pure w
         CompilerM.withLocalDecl name type fun fvar => do
           let fvarId := fvar.fvarId!
           -- Also remember (fvar → defining expression) for
@@ -2694,7 +2747,24 @@ mutual
         -- Verilog that referenced a non-existent port.
         -- (Issue #74.)
         let hwType ← inferHWTypeFromSignal exprType
+        -- Idempotency guard (Issue #107): if this exact instance
+        -- (same parent module, same child module, same input
+        -- connections) was already emitted during an earlier
+        -- leaf pass of the current module synth, reuse its
+        -- output wire instead of emitting a duplicate.  The
+        -- connections list at this point holds clk/rst + all
+        -- input-port wires, built in deterministic order, so it
+        -- serialises into a stable key.
+        let parentName := (← get).module.name
+        let connKey := String.intercalate ";"
+          (connections.reverse.map (fun (p, rhs) => s!"{p}={rhs}"))
+        let instKey := s!"{parentName}#{subModule.name}#{connKey}"
+        let instCache ← CompilerM.liftMetaM (sparkleSingleOutInstanceCache.get : IO _)
+        if let some cachedW := instCache.get? instKey then
+          return some cachedW
         let w ← CompilerM.makeWire hint hwType (named := isNamed)
+        CompilerM.liftMetaM
+          (sparkleSingleOutInstanceCache.modify (·.insert instKey w))
         connections := (singleOut.name, Sparkle.IR.AST.Expr.ref w) :: connections
         pure w
       | _multiOut =>
@@ -3190,6 +3260,7 @@ mutual
       sparkleTypeCacheMiss.set 0
       sparkleSubModuleCache.set {}
       sparkleSubInstanceOutputs.set {}
+      sparkleSingleOutInstanceCache.set {}
       sparkleFvarValueMap.set {}
       sparkleFvarWireMap.set {}
       sparkleWireWidthCache.set {}

--- a/Sparkle/IR/Optimize.lean
+++ b/Sparkle/IR/Optimize.lean
@@ -486,6 +486,142 @@ def eliminateZeroBits (m : Module) : Module :=
   let wires' := m.wires.filter (·.ty.bitWidth > 0)
   { m with body := body', wires := wires' }
 
+/-- Resolve a wire name through the CSE substitution map, following
+    chains (`w2 → w1 → w0`).  Chains are acyclic by construction —
+    a wire only enters the map when its defining statement is
+    dropped, and the representative's statement is always kept —
+    so plain recursion terminates. -/
+partial def resolveSubst (subst : HashMap String String) (w : String) : String :=
+  match subst.get? w with
+  | some w' => if w' == w then w else resolveSubst subst w'
+  | none => w
+
+/-- Rewrite every wire reference through the CSE substitution map. -/
+partial def renameRefs (subst : HashMap String String) : Expr → Expr
+  | .ref name => .ref (resolveSubst subst name)
+  | .op o args => .op o (args.map (renameRefs subst))
+  | .concat args => .concat (args.map (renameRefs subst))
+  | .slice e hi lo => .slice (renameRefs subst e) hi lo
+  | .index a i => .index (renameRefs subst a) (renameRefs subst i)
+  | e => e
+
+/-- Apply `f` to every expression embedded in a statement. -/
+def mapStmtExprs (f : Expr → Expr) : Stmt → Stmt
+  | .assign lhs rhs => .assign lhs (f rhs)
+  | .register out clk rst input init => .register out clk rst (f input) init
+  | .memory name aw dw clk wa wd we ra rd cr =>
+      .memory name aw dw clk (f wa) (f wd) (f we) (f ra) rd cr
+  | .inst mn inm conns => .inst mn inm (conns.map fun (p, e) => (p, f e))
+
+/-- Phase 0.6: cross-wire common-subexpression elimination +
+    duplicate sub-module instance merging (Issue #107).
+
+    The synth elaborator re-walks the circuit body once per register
+    next-state leaf; wires derived from `let`/loop-bound state come
+    out under fresh names per walk (`_gen_x`, `_gen_x_1`, …) even
+    though they compute identical expressions over identical base
+    wires, and each walk re-emits the sub-module instances fed by
+    those wires — E = I·(D+1) instances instead of I.  The Lean-side
+    caches can't see through the fresh fvars, but at the IR level
+    everything is canonical: the clones are literally `assign x_1 =
+    <same rhs>` and `inst … (<same input connections>)`.
+
+    Value-number assigns by their (substitution-rewritten) rhs; when
+    a later assign duplicates an earlier one, drop it and alias its
+    lhs to the representative.  Merge instances of the same module
+    whose *input* connections are identical, aliasing their output
+    wires.  A connection `.ref w` where `w` is not driven by any
+    non-instance statement (and is not a module input) is an output
+    of that instance — no cross-module port-direction table needed.
+
+    Merging stateful instances is sound: same module + same inputs +
+    same clock/reset ⇒ same state trajectory ⇒ same outputs, which
+    is exactly the denotation Sparkle's pure semantics assigns to
+    structurally identical calls.  (This is the fold yosys's
+    `opt_merge` refuses to do because it would need sequential
+    equivalence checking; here it is correct by construction.)
+
+    `protectedWire` (module outputs + observable waveform taps)
+    never gets aliased away.  Iterates to a fixpoint because folding
+    one layer of duplicates makes the next layer's keys equal. -/
+def cseAndMergeInstances (m : Module) (body0 : List Stmt)
+    (protectedWire : String → Bool) : List Stmt :=
+  Id.run do
+    let mut body := body0
+    for _ in [:16] do
+      -- Wires driven by a non-instance statement or module input.
+      -- Instance connections referencing anything else are that
+      -- instance's outputs.
+      let mut drivenElsewhere : HashMap String Bool := {}
+      for p in m.inputs do
+        drivenElsewhere := drivenElsewhere.insert p.name true
+      for s in body do
+        match s with
+        | .assign lhs _ => drivenElsewhere := drivenElsewhere.insert lhs true
+        | .register out _ _ _ _ => drivenElsewhere := drivenElsewhere.insert out true
+        | .memory _ _ _ _ _ _ _ _ rd _ => drivenElsewhere := drivenElsewhere.insert rd true
+        | .inst _ _ _ => pure ()
+      let isInstOutput : HashMap String String → (String × Expr) → Bool :=
+        fun subst (_, e) =>
+          match e with
+          | .ref w => !drivenElsewhere.contains (resolveSubst subst w)
+          | _ => false
+      let mut subst : HashMap String String := {}
+      let mut assignVN : HashMap String String := {}
+      let mut instVN : HashMap String (List (String × Expr)) := {}
+      let mut kept : List Stmt := []
+      let mut dropped := 0
+      for s0 in body do
+        let s := mapStmtExprs (renameRefs subst) s0
+        match s with
+        | .assign lhs rhs =>
+          match assignVN.get? (toString rhs) with
+          | some rep =>
+            if rep != lhs && !protectedWire lhs then
+              subst := subst.insert lhs rep
+              dropped := dropped + 1
+            else
+              kept := s :: kept
+          | none =>
+            assignVN := assignVN.insert (toString rhs) lhs
+            kept := s :: kept
+        | .inst modName _ conns =>
+          let inputConns := conns.filter (fun c => !isInstOutput subst c)
+          let inKey := String.intercalate ";"
+            (inputConns.map (fun (p, e) => s!"{p}={e}"))
+          let key := s!"{modName}|{inKey}"
+          match instVN.get? key with
+          | some repConns =>
+            -- Alias every output wire to the representative's; bail
+            -- out (keep the duplicate) if any output is protected or
+            -- shaped unexpectedly.
+            let mut mergeable := true
+            let mut aliases : List (String × String) := []
+            for (p, e) in conns do
+              if isInstOutput subst (p, e) then
+                match e, repConns.find? (fun pc => pc.1 == p) with
+                | .ref w, some (_, .ref repW) =>
+                  if protectedWire w then mergeable := false
+                  else aliases := (w, repW) :: aliases
+                | _, _ => mergeable := false
+            if mergeable then
+              for (w, repW) in aliases do
+                subst := subst.insert w repW
+              dropped := dropped + 1
+            else
+              kept := s :: kept
+          | none =>
+            instVN := instVN.insert key conns
+            kept := s :: kept
+        | _ => kept := s :: kept
+      -- Final rewrite with the complete substitution: statements kept
+      -- early in the pass may reference wires whose duplicate-drop
+      -- happened later (backward references through loop wires).
+      body := kept.reverse.map (mapStmtExprs (renameRefs subst))
+      if dropped == 0 then
+        break
+    return body
+
 /-- Optimize a module: strip zero-bit shapes, eliminate concat/slice
     chains, then remove dead code. -/
 def optimizeModule (m : Module)
@@ -557,8 +693,24 @@ def optimizeModule (m : Module)
         | _ => result := result ++ [s]
       result
 
+    -- Phase 0.6: cross-wire CSE + duplicate instance merge (Issue
+    -- #107 — the elaborator's per-register-leaf re-walks duplicate
+    -- whole logic cones and the sub-module instances they feed).
+    let outputSet0 := m.outputs.foldl (fun s p => s.insert p.name true)
+      ({} : HashMap String Bool)
+    let protectedWire := fun (w : String) =>
+      outputSet0.contains w ||
+      (match observableWires with
+       | some ws => ws.contains w
+       | none => false)
+    let cseBody := cseAndMergeInstances m dedupBody protectedWire
+    -- Rebuild the def-map: CSE renamed references, and Phase 1's
+    -- slice-of-concat resolution must not chase stale entries that
+    -- mention dropped wires.
+    let dm := buildDefMap cseBody
+
     -- Phase 1: Replace slice-of-concat with direct references
-    let optimizedBody := dedupBody.map (optimizeStmt dm wm)
+    let optimizedBody := cseBody.map (optimizeStmt dm wm)
 
     -- Phase 2: Dead code elimination
     let useCounts := countAllUses optimizedBody

--- a/Tests/Compiler/Issue107LetBoundInstanceDup.lean
+++ b/Tests/Compiler/Issue107LetBoundInstanceDup.lean
@@ -1,0 +1,130 @@
+/-
+  Regression test for Issue #107: a stateful `@[hardware_module]`
+  bound with `let` inside a `circuit do` body was emitted once per
+  elaboration pass — E = I · (D + 1) instances (I = let-bound
+  instances, D = distinct register next-state expressions) instead
+  of I.  Named translations bypass the structural `exprCache`, and
+  the single-output instance path had no idempotency guard (the
+  Issue #71 guard only covers the multi-output projection path).
+
+  Fixed by `sparkleSingleOutInstanceCache` in
+  `Sparkle/Compiler/Elab.lean`, keyed on parent module + child
+  module + input connections.
+
+  The three cases mirror the issue's minimal repro:
+  - `oneInstance`    — 1 let-bound toggle:  was 2 instances, must be 1
+  - `threeInstances` — 3 let-bound toggles: was 12 instances, must be 3
+    (also guards the key granularity: folding `toggle e0/e1/e2`
+    into fewer than 3 instances would be a miscompile)
+  - `controlInline`  — inlined call, always worked: must stay 1
+-/
+import Sparkle
+import Sparkle.Compiler.Elab
+
+namespace Sparkle.Tests.Compiler.Issue107LetBoundInstanceDup
+
+open Sparkle.Core.Domain
+open Sparkle.Core.Signal
+
+/-- Stateful sub-module: a 1-bit register that flips when `en` is high. -/
+@[hardware_module]
+def toggle {dom : DomainConfig} (en : Signal dom Bool) : Signal dom Bool :=
+  Signal.loop fun (s : Signal dom Bool) =>
+    Signal.register false (Signal.mux en (~~~s) s)
+
+/-- One let-bound instantiation. -/
+@[hardware_module]
+def oneInstance {dom : DomainConfig} (en : Signal dom Bool) : Signal dom Bool := circuit do
+  let r0 ← Signal.reg false
+  let t := toggle en
+  r0 <~ t
+  return (r0 : Signal dom Bool)
+
+/-- Three distinct let-bound instantiations (distinct args — must NOT fold). -/
+@[hardware_module]
+def threeInstances {dom : DomainConfig} (e0 e1 e2 : Signal dom Bool) : Signal dom Bool := circuit do
+  let r0 ← Signal.reg false
+  let r1 ← Signal.reg false
+  let r2 ← Signal.reg false
+  let a := toggle e0
+  let b := toggle e1
+  let c := toggle e2
+  r0 <~ a
+  r1 <~ b
+  r2 <~ c
+  return ((r0 : Signal dom Bool) &&& (r1 : Signal dom Bool) &&& (r2 : Signal dom Bool))
+
+/-- Control — same as `oneInstance` but the call is inlined, not let-bound. -/
+@[hardware_module]
+def controlInline {dom : DomainConfig} (en : Signal dom Bool) : Signal dom Bool := circuit do
+  let r0 ← Signal.reg false
+  r0 <~ toggle en
+  return (r0 : Signal dom Bool)
+
+/-- Router variant (the NoC `router5` shape): the sub-module call's
+    argument goes through a `let` whose value reads register state.
+    Each elaboration re-walk then materialises the argument cone under
+    fresh fvars, so the elaborator-side instance guard cannot fire
+    (the connections differ textually per walk) — only the IR-level
+    CSE + instance-merge pass folds these. -/
+@[hardware_module]
+def stateArg {dom : DomainConfig} (en : Signal dom Bool) : Signal dom Bool := circuit do
+  let r0 ← Signal.reg false
+  let r1 ← Signal.reg false
+  let g := (r0 : Signal dom Bool) &&& en
+  let t := toggle g
+  r1 <~ t
+  r0 <~ en
+  return (r1 : Signal dom Bool)
+
+open Lean Elab Command in
+/-- Synthesize `id` and assert its module body contains exactly `n`
+    sub-module instantiations.  Fails elaboration (and hence the
+    build) on mismatch. -/
+elab "#assertInstCount" id:ident n:num : command => do
+  let declName ← liftCoreM (Lean.resolveGlobalConstNoOverload id)
+  liftTermElabM do
+    let (module, _) ← Sparkle.Compiler.Elab.synthesizeCombinational declName
+    let count := module.body.filter (fun s => match s with
+      | Sparkle.IR.AST.Stmt.inst .. => true
+      | _ => false) |>.length
+    unless count == n.getNat do
+      throwError "Issue #107 regression: expected {n.getNat} sub-module instance(s) in {declName}, found {count}"
+
+open Lean Elab Command in
+/-- Like `#assertInstCount`, but counts instances AFTER the IR
+    optimizer (what actually reaches the emitted Verilog) — this is
+    what exercises the CSE + duplicate-instance-merge pass. -/
+elab "#assertInstCountOptimized" id:ident n:num : command => do
+  let declName ← liftCoreM (Lean.resolveGlobalConstNoOverload id)
+  liftTermElabM do
+    let (module, _) ← Sparkle.Compiler.Elab.synthesizeCombinational declName
+    let optimized := Sparkle.IR.Optimize.optimizeModule module
+    let count := optimized.body.filter (fun s => match s with
+      | Sparkle.IR.AST.Stmt.inst .. => true
+      | _ => false) |>.length
+    unless count == n.getNat do
+      throwError "Issue #107 regression: expected {n.getNat} optimized sub-module instance(s) in {declName}, found {count}"
+
+-- Elaborator-side guard (pre-optimizer): pass-stable connections
+-- must dedupe during elaboration.
+#assertInstCount oneInstance 1
+#assertInstCount threeInstances 3
+#assertInstCount controlInline 1
+
+-- Netlist contract (post-optimizer): what ships to Verilog.  The
+-- threeInstances case also guards against over-merging — its three
+-- calls take distinct arguments and must all survive.
+#assertInstCountOptimized oneInstance 1
+#assertInstCountOptimized threeInstances 3
+#assertInstCountOptimized controlInline 1
+#assertInstCountOptimized stateArg 1
+
+def main : IO Unit := do
+  IO.println "Issue107LetBoundInstanceDup: build-only regression test."
+  IO.println "  ✓ oneInstance    emits exactly 1 toggle instance (was 2)"
+  IO.println "  ✓ threeInstances emits exactly 3 toggle instances (was 12)"
+  IO.println "  ✓ controlInline  emits exactly 1 toggle instance"
+  IO.println "  ✓ stateArg       optimizes to exactly 1 toggle instance (router variant)"
+
+end Sparkle.Tests.Compiler.Issue107LetBoundInstanceDup

--- a/Tests/Drivers/Issue107LetBoundInstanceDupMain.lean
+++ b/Tests/Drivers/Issue107LetBoundInstanceDupMain.lean
@@ -1,0 +1,4 @@
+import Tests.Compiler.Issue107LetBoundInstanceDup
+
+def main : IO Unit :=
+  Sparkle.Tests.Compiler.Issue107LetBoundInstanceDup.main

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -576,6 +576,15 @@ lean_exe «multi-output-submodule-hang-repro» where
   root := `Tests.Drivers.MultiOutputSubModuleHangReproMain
   supportInterpreter := true
 
+-- Regression guard for Issue #107: a `let`-bound stateful
+-- @[hardware_module] inside `circuit do` must emit exactly one
+-- instance per source instantiation (was E = I·(D+1)).  The
+-- asserts run at elaboration time, so `lake build` of this
+-- target IS the test.
+lean_exe «issue107-letbound-instance-dup-test» where
+  root := `Tests.Drivers.Issue107LetBoundInstanceDupMain
+  supportInterpreter := true
+
 lean_exe «x25519-test» where
   root := `Tests.Drivers.X25519TestMain
   supportInterpreter := true


### PR DESCRIPTION
I messed around with Fable to get this.  I tested it on my own little design, the case described in the ticket and I also ran on the IP blocks that don't have prior issues.

I'm not competent enough in the code base to fully review this change so do throw this away if it does not meet your standards.