### PR TITLE
fix(test): hold sponge message lanes for the whole run (#112)

### DIFF
--- a/Tests/IP/Crypto/Keccak256SpongeJITTest.lean
+++ b/Tests/IP/Crypto/Keccak256SpongeJITTest.lean
@@ -100,12 +100,19 @@ private def runSponge (sim : Simulator) (input : Array UInt8) : IO (Array UInt8)
   -- stopped duplicating it, the loop hit the cap and silently returned
   -- the UNPERMUTED state — which reads as a wrong digest, not a
   -- timeout.  Hence the explicit failure below.)
-  let zeroLanes : Array (BitVec 64) := Array.replicate (rateLanes * maxBlocks) 0#64
+  --
+  -- The message lanes MUST be held for the whole run, not zeroed after the
+  -- start pulse: the block-loop XORs block 1's lanes (`m17..m33`) into the
+  -- permuted state on the CONTINUE cycle, which is ~28 cycles in.  Feeding
+  -- zeros there absorbs an all-zero second block — a wrong digest for every
+  -- multi-block input, which was tracked as issue #112.  The circuit was
+  -- always correct (a `Signal.val` co-sim holding the lanes matches
+  -- `keccak256OfBytes` for 136B/200B); the bug was here, in the driver.
   let cap := 200 + maxBlocks * 64
   let mut out ← sim.read
   let mut cyc := 0
   while out.done == 0#1 && cyc < cap do
-    sim.step (mkInput false nBlocks zeroLanes)
+    sim.step (mkInput false nBlocks lanes)
     out ← sim.read
     cyc := cyc + 1
   if out.done == 0#1 then


### PR DESCRIPTION
Closes #112.

The 136B/200B multi-block sponge fixtures produced the wrong digest —
both the *same* wrong value, which read like "block 1 never absorbed" and
was carved out of #95 as a suspected pre-existing circuit bug.

It is not a circuit bug. The JIT driver was wrong: `runSponge` pulsed
`start` with the message lanes on cycle 0, then held `start` low **and
fed zeroed lanes** for the rest of the run. The sponge's block loop XORs
block 1's lanes (`m17..m33`) into the permuted state on the *continue*
cycle, ~28 cycles in — long after the driver had switched the lanes to
zero. So block 1 was absorbed as all-zeros.

Found with the `Signal.val` co-sim that #95's fix made possible: stepping
the sponge cycle-by-cycle on a 136-byte input, the state after block 0
(t=27) and after block 1 (t=54) both match `absorbBlock` from the pure
reference *exactly*, and the full digest matches `keccak256OfBytes` — as
long as the lanes are held. Zeroing them after t=0 reproduces the JIT
test's wrong value in the interpreter too, which pinned it on the driver.

Fix: feed `lanes` (not `zeroLanes`) every cycle — the message is a held
input, which is what real hardware sees.

```
empty ✓  abc ✓  136B ✓  200B ✓   (was: 136B/200B ✗, identical wrong value)
```

One line of driver change; the circuit is untouched.

Follow-up worth doing (not in this PR): the sponge JIT test still isn't in
any CI workflow. Wiring `keccak256-sponge-jit-test` into the IP matrix
would have caught this driver bug — and any real multi-block regression —
immediately.
