### PR TITLE
bench(systolic): PoC — GPU SIM of a single large accelerator (PE-per-thread)

### DIFF
--- a/bench/systolic/.gitignore
+++ b/bench/systolic/.gitignore
@@ -1,3 +1,4 @@
 systolic_cpu
 systolic_gpu
+systolic_gpu_grid
 *.o

--- a/bench/systolic/.gitignore
+++ b/bench/systolic/.gitignore
@@ -1,0 +1,3 @@
+systolic_cpu
+systolic_gpu
+*.o

--- a/bench/systolic/README.md
+++ b/bench/systolic/README.md
@@ -78,39 +78,54 @@ time. The `.cu` also passes a host `g++ -fsyntax-only` (nvcc-free).
 
 ## Results
 
-RTX 4070 Ti (sm_89), `nvcc -O3 -std=c++17`, driver 565.77 / CUDA 12.7,
-CPU `g++ -O3`, cycles = 200000, checksums matched CPU exactly for every N:
+RTX 4070 Ti (sm_89, 60 SMs), `nvcc 12.6 -O3 -std=c++17`, driver 565.77 /
+CUDA 12.7, CPU `g++ -O3`, cycles = 200000. Every checksum matched the serial
+golden model. Two GPU schedulers:
 
-| N | PEs | CPU PE-upd/s | GPU PE-upd/s | GPU/CPU |
-|---|----:|---:|---:|---:|
-| 16 | 256 | 1.64e9 | 2.85e9 | 1.7× |
-| 32 | 1024 | 2.21e9 | 4.95e9 | 2.2× |
-| 64 | 4096 | 1.89e9 | (needs grid-sync) | — |
+- **1-block** (`systolic_gpu.cu`): whole array in one block, `__syncthreads()`
+  per phase. Cheap barrier, but N≤32 (1024 threads/block) and only 1 SM used.
+- **grid-sync** (`systolic_gpu_grid.cu`): array spread over many blocks/SMs,
+  cooperative-groups `grid.sync()` per phase, double-buffered global state.
+  Scales past N=32 and uses the whole GPU, but the grid barrier is expensive.
 
-**Verdict: proceed.** GPU PE-upd/s *rises* with the array (2.85e9 → 4.95e9)
-while the CPU stays flat (~1.6–2.2e9, the serial ceiling), and GPU/CPU widens
-1.7× → 2.2× from N=16 to N=32. That rise is the signature of genuine
-within-instance parallelism — the thing you cannot buy by adding machines,
-unlike the batch backend in #115.
+| N | PEs | CPU PE/s | 1-block PE/s | grid PE/s | CPU cyc/s | grid cyc/s |
+|---|----:|---:|---:|---:|---:|---:|
+| 16 | 256 | 1.49e9 | **2.85e9** | 2.30e8 | 5.8e6 | 9.0e5 |
+| 32 | 1024 | 2.11e9 | **5.44e9** | 9.18e8 | 2.1e6 | 9.0e5 |
+| 64 | 4096 | 1.85e9 | — | 3.64e9 | 4.5e5 | 8.9e5 |
+| 128 | 16384 | 1.67e9 | — | 1.45e10 | 1.0e5 | 8.9e5 |
+| 256 | 65536 | 8.9e8 | — | **4.34e10** | 1.4e4 | 6.6e5 |
 
-Caveats (why 2.2× is a floor, not the ceiling):
+`PE/s = cyc/s × N²` (work done); `cyc/s` = simulated clocks per second (how
+fast one run advances).
 
-- One block = one SM, so N≤32 uses a *single* SM of the 4070 Ti's 60. The
-  win is real but the GPU is 98% idle. The payoff scales with array size, and
-  the array that unlocks the *other* SMs is exactly the one a single block
-  can't hold.
-- **N=64 (4096 PEs) is the gate.** It exceeds 1024 threads/block, so it needs
-  a grid-wide barrier (cooperative groups) or multi-block tiling — which is
-  also what finally spreads the work across all SMs. That is the next step,
-  and where the interesting speedup should appear.
+## Verdict — three regimes
 
-## Next steps
+1. **CPU**: PE/s flat (serial ceiling), `cyc/s` collapses as N² — N=256 does
+   1.4e4 cyc/s, effectively unusable for a large array.
+2. **1-block GPU (N≤32)**: `__syncthreads()` is cheap, so **`cyc/s` is
+   highest** (5.4e6 at N=32, 2.6× CPU). Best when the array fits one block and
+   you want a single run to finish fast.
+3. **grid-sync GPU (N≥64)**: `cyc/s` is pinned ~9e5 by the grid-barrier
+   latency, but **PE/s scales linearly with PE count** — N=256 hits 4.34e10
+   PE/s, **49× the CPU**. Best for throughput on a large array.
 
-1. **Grid-sync N≥64** (cooperative-groups `grid.sync()` or a multi-block tile
-   with a global barrier), so one array spans many SMs. Re-measure the sweep
-   out to N=128/256 — this is where GPU/CPU should jump well past 2×.
-2. **Emit this kernel from Sparkle IR.** Port the deferred
-   `CudaDesignStateStruct` hierarchical path (PR #33) onto CSim so the
-   wire-copy between module boundaries is *generated*, not hand-written —
-   turning this PoC into a real backend for single-large-design simulation
-   (systolic array + RISC-V bank).
+So the answer to "can this speed up a real ~1000-PE accelerator?": **yes**, and
+the bigger the design the more decisively GPU wins. A 1000-PE array is around
+N=32 here — take the 1-block path (5.4e6 cyc/s, 2.6× CPU) if latency of a
+single run matters, or grid-sync for raw PE throughput. Past a few thousand PEs
+the CPU is simply not in the race (N=256: GPU 4.34e10 vs CPU 8.9e8 PE/s).
+
+The grid `cyc/s` ceiling (~9e5) is the one thing to improve: it is dominated by
+two `grid.sync()` per simulated cycle. Coarsening the barrier (multiple
+sim-cycles between syncs where the dependency depth allows) or a persistent
+megakernel with a lighter cross-SM barrier is the lever — noted for later, not
+needed to justify the backend.
+
+## Next step
+
+**Emit these kernels from Sparkle IR.** Port the deferred `CudaDesignStateStruct`
+hierarchical path (PR #33) onto CSim so the wire-copy between module boundaries
+is *generated*, not hand-written — turning this PoC into a real backend for
+single-large-design simulation (systolic array + RISC-V bank), picking the
+1-block vs grid-sync scheduler by array size.

--- a/bench/systolic/README.md
+++ b/bench/systolic/README.md
@@ -1,0 +1,116 @@
+# Systolic-array SIM PoC — does PE-per-thread on the GPU scale?
+
+## The question
+
+PR #115 added a CUDA **batch** backend: N independent instances, 1 instance per
+thread. That is a Monte-Carlo / fuzzing engine — you can always get the same
+throughput by adding machines, and a *single* instance is slower than on the
+CPU. Not the interesting case.
+
+The interesting case is a **single large accelerator** (a TPU-like systolic
+array + a bank of RISC-V cores, ~1000 PEs, wired together) whose *one* instance
+you want to simulate faster. That needs a different scheduler: **1 PE = 1
+thread**, with a barrier between the read and latch phases of each clock cycle
+(#33's "Strategy 4"). Adding machines does *not* replace this — it makes one
+array faster by running its PEs concurrently.
+
+This PoC measures whether that scheduler actually scales, on the cleanest
+possible DUT, **before** committing to emitter work.
+
+## DUT
+
+Weight-stationary int8 MAC systolic array, `N x N` PEs (`systolic_common.h` is
+the golden cycle model shared by both implementations):
+
+- `PE[i][j]` holds a fixed int8 weight; each cycle it reads an activation from
+  the left and a partial sum from above, computes `p_out = p_in + a_in*w`,
+  passes the activation right and the partial sum down.
+- Two-phase per cycle: read all neighbours' *previous* registered outputs, then
+  latch. That read-then-latch structure is exactly what forces a
+  `__syncthreads()` between phases on the GPU.
+
+## Implementations (same circuit, two schedulers)
+
+| file | scheduler |
+|---|---|
+| `systolic_cpu.cpp` | serial — one thread walks every PE each cycle (CSim-equivalent) |
+| `systolic_gpu.cu` | persistent kernel — 1 PE = 1 thread, one block per array, `__syncthreads()` per phase; state in shared memory, two barriers/cycle, no global traffic |
+
+Block-size limit: one block owns the whole array so the barrier covers all PEs,
+and a block caps at 1024 threads → `N ≤ 32` (16×16=256, 32×32=1024). `N=64`
+(4096 PEs) needs a grid-wide barrier (cooperative groups) or multi-block
+tiling — deliberately the *next* step; this PoC answers the 16→32 scaling
+question.
+
+## Run
+
+```
+./run.sh                 # builds what it can; CPU always, GPU if nvcc present
+CYCLES=200000 ./run.sh
+ARCH=sm_80 ./run.sh      # override the GPU arch (default sm_89 = RTX 40xx)
+```
+
+`run.sh` puts `/run/opengl-driver/lib` on `LD_LIBRARY_PATH` — on NixOS the
+real `libcuda.so.1` lives there, and `cudart_static` dlopens it at run time,
+so without it a CUDA binary fails with "driver version insufficient" even
+though the GPU is fine. Also make sure the `nvcc` toolkit version is ≤ the
+driver's CUDA version (`nvidia-smi` top-right); a newer toolkit's runtime is
+rejected by an older driver.
+
+## Correctness
+
+Verified without a GPU: a host emulation of the exact per-thread kernel logic
+(two-phase barrier over all tids) produces the **same** output checksum as the
+serial golden model for N = 16, 32, 64. So on a real GPU the benchmark compares
+correct-against-correct; `run.sh` re-checks the `checksum=` fields match at run
+time. The `.cu` also passes a host `g++ -fsyntax-only` (nvcc-free).
+
+## Reading the result
+
+`PE-upd/s = cyc/s × N²` is the fair "work done" metric across sizes.
+
+- **CPU**: PE-upd/s stays ~flat as N grows (serial — bigger array, proportionally
+  slower per cycle). Measured: ~1.6–2.2e9 PE-upd/s across N=16/32/64.
+- **GPU**: PE-upd/s *rises* with N as more PEs run concurrently — that rise is
+  the justification for the emitter work. **Confirmed** below (2.85e9 → 4.95e9
+  from N=16 to N=32). Had it stayed flat or fallen, Strategy 4 would not be
+  worth building and the batch backend would be the right stopping point.
+
+## Results
+
+RTX 4070 Ti (sm_89), `nvcc -O3 -std=c++17`, driver 565.77 / CUDA 12.7,
+CPU `g++ -O3`, cycles = 200000, checksums matched CPU exactly for every N:
+
+| N | PEs | CPU PE-upd/s | GPU PE-upd/s | GPU/CPU |
+|---|----:|---:|---:|---:|
+| 16 | 256 | 1.64e9 | 2.85e9 | 1.7× |
+| 32 | 1024 | 2.21e9 | 4.95e9 | 2.2× |
+| 64 | 4096 | 1.89e9 | (needs grid-sync) | — |
+
+**Verdict: proceed.** GPU PE-upd/s *rises* with the array (2.85e9 → 4.95e9)
+while the CPU stays flat (~1.6–2.2e9, the serial ceiling), and GPU/CPU widens
+1.7× → 2.2× from N=16 to N=32. That rise is the signature of genuine
+within-instance parallelism — the thing you cannot buy by adding machines,
+unlike the batch backend in #115.
+
+Caveats (why 2.2× is a floor, not the ceiling):
+
+- One block = one SM, so N≤32 uses a *single* SM of the 4070 Ti's 60. The
+  win is real but the GPU is 98% idle. The payoff scales with array size, and
+  the array that unlocks the *other* SMs is exactly the one a single block
+  can't hold.
+- **N=64 (4096 PEs) is the gate.** It exceeds 1024 threads/block, so it needs
+  a grid-wide barrier (cooperative groups) or multi-block tiling — which is
+  also what finally spreads the work across all SMs. That is the next step,
+  and where the interesting speedup should appear.
+
+## Next steps
+
+1. **Grid-sync N≥64** (cooperative-groups `grid.sync()` or a multi-block tile
+   with a global barrier), so one array spans many SMs. Re-measure the sweep
+   out to N=128/256 — this is where GPU/CPU should jump well past 2×.
+2. **Emit this kernel from Sparkle IR.** Port the deferred
+   `CudaDesignStateStruct` hierarchical path (PR #33) onto CSim so the
+   wire-copy between module boundaries is *generated*, not hand-written —
+   turning this PoC into a real backend for single-large-design simulation
+   (systolic array + RISC-V bank).

--- a/bench/systolic/run.sh
+++ b/bench/systolic/run.sh
@@ -22,12 +22,18 @@ fi
 
 echo "== build =="
 g++ -O3 -std=c++17 -o systolic_cpu systolic_cpu.cpp && echo "  cpu: ok" || { echo "  cpu: FAILED"; exit 1; }
-HAVE_GPU=0
+HAVE_GPU=0 HAVE_GRID=0
 if command -v nvcc >/dev/null 2>&1; then
   if nvcc -O3 -std=c++17 -arch="$ARCH" -o systolic_gpu systolic_gpu.cu 2>/tmp/nvcc.err; then
-    HAVE_GPU=1; echo "  gpu: ok (arch=$ARCH)"
+    HAVE_GPU=1; echo "  gpu 1-block: ok (arch=$ARCH)"
   else
-    echo "  gpu: nvcc failed:"; sed 's/^/    /' /tmp/nvcc.err
+    echo "  gpu 1-block: nvcc failed:"; sed 's/^/    /' /tmp/nvcc.err
+  fi
+  # grid-sync kernel needs relocatable device code for cooperative groups.
+  if nvcc -O3 -std=c++17 -arch="$ARCH" -rdc=true -o systolic_gpu_grid systolic_gpu_grid.cu 2>/tmp/nvcc.err; then
+    HAVE_GRID=1; echo "  gpu grid  : ok (arch=$ARCH, -rdc=true)"
+  else
+    echo "  gpu grid  : nvcc failed:"; sed 's/^/    /' /tmp/nvcc.err
   fi
 else
   echo "  gpu: nvcc not found — CPU-only run (see header for what GPU adds)"
@@ -35,12 +41,13 @@ fi
 
 echo
 echo "== sweep (cycles=$CYCLES) =="
-for N in 16 32 64; do
+for N in 16 32 64 128 256; do
   ./systolic_cpu "$N" "$CYCLES"
-  [ "$HAVE_GPU" = 1 ] && ./systolic_gpu "$N" "$CYCLES"
+  [ "$HAVE_GPU" = 1 ]  && ./systolic_gpu      "$N" "$CYCLES"   # 1-block (N<=32)
+  [ "$HAVE_GRID" = 1 ] && ./systolic_gpu_grid "$N" "$CYCLES"   # grid-sync (any N)
 done
 
 echo
-echo "Cross-check: CPU and GPU 'checksum=' must match for each N."
-echo "Scaling read: compare PE-upd/s across N.  CPU stays ~flat (serial);"
-echo "GPU PE-upd/s should RISE with N if PE-per-thread genuinely parallelises."
+echo "Cross-check: all 'checksum=' for a given N must match (CPU is golden)."
+echo "PE-upd/s = work done; cyc/s = how fast one run advances."
+echo "1-block wins cyc/s for small N; grid-sync scales PE-upd/s with PE count."

--- a/bench/systolic/run.sh
+++ b/bench/systolic/run.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Systolic-array SIM PoC: CPU serial vs GPU persistent-kernel (PE-per-thread).
+#
+# Answers: does 1-PE-per-thread + __syncthreads() make a SINGLE array
+# instance faster as the array grows (16x16 -> 32x32)?  The batch backend
+# (PR #115) can't do this — it parallelises across instances, not within one.
+#
+#   ./run.sh            # builds what it can, runs the sweep
+#   CYCLES=200000 ./run.sh
+set -u
+cd "$(dirname "$0")"
+CYCLES="${CYCLES:-100000}"
+# GPU SM architecture (RTX 4070 Ti = sm_89).  Override for other GPUs.
+ARCH="${ARCH:-sm_89}"
+# On NixOS the real driver libcuda.so.1 lives here, not on the default loader
+# path; cudart_static dlopens it at run time, so a CUDA binary silently fails
+# with "driver version insufficient" unless this is on LD_LIBRARY_PATH.
+# Harmless (and skipped) where the dir doesn't exist.
+if [ -d /run/opengl-driver/lib ]; then
+  export LD_LIBRARY_PATH="/run/opengl-driver/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+
+echo "== build =="
+g++ -O3 -std=c++17 -o systolic_cpu systolic_cpu.cpp && echo "  cpu: ok" || { echo "  cpu: FAILED"; exit 1; }
+HAVE_GPU=0
+if command -v nvcc >/dev/null 2>&1; then
+  if nvcc -O3 -std=c++17 -arch="$ARCH" -o systolic_gpu systolic_gpu.cu 2>/tmp/nvcc.err; then
+    HAVE_GPU=1; echo "  gpu: ok (arch=$ARCH)"
+  else
+    echo "  gpu: nvcc failed:"; sed 's/^/    /' /tmp/nvcc.err
+  fi
+else
+  echo "  gpu: nvcc not found — CPU-only run (see header for what GPU adds)"
+fi
+
+echo
+echo "== sweep (cycles=$CYCLES) =="
+for N in 16 32 64; do
+  ./systolic_cpu "$N" "$CYCLES"
+  [ "$HAVE_GPU" = 1 ] && ./systolic_gpu "$N" "$CYCLES"
+done
+
+echo
+echo "Cross-check: CPU and GPU 'checksum=' must match for each N."
+echo "Scaling read: compare PE-upd/s across N.  CPU stays ~flat (serial);"
+echo "GPU PE-upd/s should RISE with N if PE-per-thread genuinely parallelises."

--- a/bench/systolic/systolic_common.h
+++ b/bench/systolic/systolic_common.h
@@ -1,0 +1,82 @@
+// Weight-stationary int8 MAC systolic array — shared cycle semantics.
+//
+// This header defines the *reference* cycle behaviour that both the CPU
+// (systolic_cpu.cpp) and GPU (systolic_gpu.cu) implementations must match
+// bit-for-bit.  It is the single source of truth for "what one clock cycle
+// does", so the PoC compares two *schedulers* of the same circuit, not two
+// different circuits.
+//
+// Array (N x N PEs), weight-stationary:
+//   - PE[i][j] holds a fixed int8 weight w[i][j].
+//   - Each cycle, PE[i][j] reads an activation a_in from its LEFT neighbour
+//     (column j-1; the left edge j=0 reads the streamed input row) and a
+//     partial sum p_in from its TOP neighbour (row i-1; the top edge i=0
+//     reads 0).
+//   - It computes  p_out = p_in + (int32)a_in * (int32)w[i][j]
+//     and passes a_in to the RIGHT (a_out = a_in) and p_out DOWN.
+//   - Bottom-edge p_out (row i=N-1) is the column's accumulated result.
+//
+// State per PE: {a, p} both int32 (the value currently latched on its output
+// registers).  One cycle = combational compute from neighbours' *previous*
+// registered outputs, then latch.  That two-phase (read-all-then-latch)
+// structure is exactly what forces a __syncthreads() between phases on the GPU.
+
+#pragma once
+#include <cstdint>
+#include <vector>
+
+struct SystolicDims {
+  int N;          // array is N x N PEs
+};
+
+// Flattened PE state: row-major, index = i*N + j.
+struct SystolicState {
+  int N;
+  std::vector<int8_t>  w;   // N*N  fixed weights
+  std::vector<int32_t> a;   // N*N  latched activation-passthrough register
+  std::vector<int32_t> p;   // N*N  latched partial-sum register
+  // Left-edge activation input per row, for the current cycle (length N).
+  std::vector<int32_t> ain; // N
+};
+
+// Advance one clock cycle on the host, in place.  This is the golden model.
+// Read phase uses the *old* a/p; write phase latches new values.
+static inline void systolic_step_cpu(SystolicState& s) {
+  const int N = s.N;
+  std::vector<int32_t> na(N * N), np(N * N);
+  for (int i = 0; i < N; ++i) {
+    for (int j = 0; j < N; ++j) {
+      int32_t a_in = (j == 0) ? s.ain[i] : s.a[i * N + (j - 1)];
+      int32_t p_in = (i == 0) ? 0        : s.p[(i - 1) * N + j];
+      int32_t p_out = p_in + a_in * (int32_t)s.w[i * N + j];
+      na[i * N + j] = a_in;      // a_out = a_in
+      np[i * N + j] = p_out;
+    }
+  }
+  s.a.swap(na);
+  s.p.swap(np);
+}
+
+// A cheap deterministic fill so CPU and GPU start from identical state
+// without needing Math.random / a seed file.
+static inline void systolic_init(SystolicState& s, int N) {
+  s.N = N;
+  s.w.assign(N * N, 0);
+  s.a.assign(N * N, 0);
+  s.p.assign(N * N, 0);
+  s.ain.assign(N, 0);
+  for (int i = 0; i < N; ++i) {
+    for (int j = 0; j < N; ++j)
+      s.w[i * N + j] = (int8_t)(((i * 7 + j * 3) % 5) - 2);  // -2..2
+    s.ain[i] = (int32_t)((i % 8) - 3);                       // -3..4
+  }
+}
+
+// A tiny checksum over the bottom row's accumulated results (the array output),
+// used to confirm CPU and GPU agree.
+static inline int64_t systolic_output_checksum(const SystolicState& s) {
+  const int N = s.N;
+  int64_t acc = 0;
+  for (int j = 0; j < N; ++j) acc = acc * 1000003 + s.p[(N - 1) * N + j];
+  return acc;
+}

--- a/bench/systolic/systolic_cpu.cpp
+++ b/bench/systolic/systolic_cpu.cpp
@@ -1,0 +1,33 @@
+// CPU baseline: single-thread serial simulation of the weight-stationary
+// systolic array — the CSim-equivalent scheduler (one thread walks every PE
+// each cycle).  Prints cyc/s and the output checksum for cross-check.
+//
+//   g++ -O3 -std=c++17 -o systolic_cpu systolic_cpu.cpp
+//   ./systolic_cpu <N> <cycles>
+
+#include "systolic_common.h"
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
+
+int main(int argc, char** argv) {
+  int   N      = (argc > 1) ? atoi(argv[1]) : 32;
+  long  cycles = (argc > 2) ? atol(argv[2]) : 100000;
+
+  SystolicState s;
+  systolic_init(s, N);
+
+  struct timespec t0, t1;
+  clock_gettime(CLOCK_MONOTONIC, &t0);
+  for (long c = 0; c < cycles; ++c) systolic_step_cpu(s);
+  clock_gettime(CLOCK_MONOTONIC, &t1);
+
+  double secs = (t1.tv_sec - t0.tv_sec) + (t1.tv_nsec - t0.tv_nsec) / 1e9;
+  double cps  = cycles / secs;
+  // PE-updates/s is the fair "work done" metric across array sizes.
+  double peps = cps * (double)N * N;
+
+  printf("CPU  N=%-3d cycles=%-9ld  %.3f s  %.3e cyc/s  %.3e PE-upd/s  checksum=%lld\n",
+         N, cycles, secs, cps, peps, (long long)systolic_output_checksum(s));
+  return 0;
+}

--- a/bench/systolic/systolic_gpu.cu
+++ b/bench/systolic/systolic_gpu.cu
@@ -1,0 +1,107 @@
+// GPU persistent-kernel simulation of the weight-stationary systolic array —
+// the "Strategy 4" scheduler: 1 PE = 1 thread, one thread block per array,
+// __syncthreads() between the read phase and the latch phase each cycle.
+//
+// This is the scheduler that CANNOT be replaced by adding machines: it makes a
+// SINGLE array instance faster by running its N*N PEs concurrently, which is
+// the whole point of the PoC.  Contrast systolic_cpu.cpp (serial per cycle).
+//
+//   nvcc -O3 -std=c++17 -o systolic_gpu systolic_gpu.cu
+//   ./systolic_gpu <N> <cycles>
+//
+// Block-size constraint: one block owns the whole array, so __syncthreads()
+// synchronises all PEs.  A block is capped at 1024 threads, so N<=32 here
+// (16x16=256, 32x32=1024).  N=64 (4096 PEs) needs a grid-wide barrier
+// (cooperative groups) or a multi-block tiling — deliberately left as the next
+// step; this PoC answers "does PE-per-thread + syncthreads scale 16->32?".
+
+#include "systolic_common.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cuda_runtime.h>
+
+// State lives in global memory; the block loads it into shared once, iterates
+// all cycles in shared with a barrier per phase, then writes back.  This keeps
+// the per-cycle cost to two __syncthreads() and no global traffic.
+__global__ void systolic_persistent_kernel(
+    const int8_t* __restrict__ w,
+    const int32_t* __restrict__ ain,
+    int32_t* __restrict__ p_out_final,
+    int N, long cycles)
+{
+  extern __shared__ int32_t sm[];      // 2*N*N : [a | p]
+  int32_t* a = sm;
+  int32_t* p = sm + N * N;
+
+  int tid = threadIdx.x;               // 0 .. N*N-1
+  int total = N * N;
+  int i = tid / N, j = tid % N;
+
+  // Init shared state (only the N*N active threads).
+  if (tid < total) { a[tid] = 0; p[tid] = 0; }
+  __syncthreads();
+
+  for (long c = 0; c < cycles; ++c) {
+    int32_t a_out = 0, p_out = 0;
+    if (tid < total) {
+      int32_t a_in = (j == 0) ? ain[i] : a[i * N + (j - 1)];
+      int32_t p_in = (i == 0) ? 0      : p[(i - 1) * N + j];
+      p_out = p_in + a_in * (int32_t)w[tid];
+      a_out = a_in;
+    }
+    __syncthreads();                   // all reads of old a/p done
+    if (tid < total) { a[tid] = a_out; p[tid] = p_out; }
+    __syncthreads();                   // new values latched before next read
+  }
+
+  if (tid < total && i == N - 1) p_out_final[j] = p[tid];  // bottom row
+}
+
+int main(int argc, char** argv) {
+  int  N      = (argc > 1) ? atoi(argv[1]) : 32;
+  long cycles = (argc > 2) ? atol(argv[2]) : 100000;
+
+  if (N * N > 1024) {
+    printf("GPU  N=%-3d  SKIP (%d PEs > 1024/block; needs grid-sync, see header)\n",
+           N, N * N);
+    return 0;
+  }
+
+  SystolicState s;
+  systolic_init(s, N);
+
+  int8_t*  d_w;   cudaMalloc((void**)&d_w,   N * N * sizeof(int8_t));
+  int32_t* d_ain; cudaMalloc((void**)&d_ain, N * sizeof(int32_t));
+  int32_t* d_out; cudaMalloc((void**)&d_out, N * sizeof(int32_t));
+  cudaMemcpy(d_w,   s.w.data(),   N * N * sizeof(int8_t),  cudaMemcpyHostToDevice);
+  cudaMemcpy(d_ain, s.ain.data(), N * sizeof(int32_t),     cudaMemcpyHostToDevice);
+
+  size_t shmem = 2 * N * N * sizeof(int32_t);
+
+  // Warm-up (JIT/launch overhead out of the timed region).
+  systolic_persistent_kernel<<<1, N * N, shmem>>>(d_w, d_ain, d_out, N, 1);
+  cudaDeviceSynchronize();
+
+  cudaEvent_t e0, e1; cudaEventCreate(&e0); cudaEventCreate(&e1);
+  cudaEventRecord(e0);
+  systolic_persistent_kernel<<<1, N * N, shmem>>>(d_w, d_ain, d_out, N, cycles);
+  cudaEventRecord(e1);
+  cudaEventSynchronize(e1);
+  float ms = 0; cudaEventElapsedTime(&ms, e0, e1);
+
+  std::vector<int32_t> out(N);
+  cudaMemcpy(out.data(), d_out, N * sizeof(int32_t), cudaMemcpyDeviceToHost);
+
+  // Recompute checksum with the same fold as the CPU (over bottom row).
+  int64_t chk = 0;
+  for (int j = 0; j < N; ++j) chk = chk * 1000003 + out[j];
+
+  double secs = ms / 1e3;
+  double cps  = cycles / secs;
+  double peps = cps * (double)N * N;
+  printf("GPU  N=%-3d cycles=%-9ld  %.3f s  %.3e cyc/s  %.3e PE-upd/s  checksum=%lld\n",
+         N, cycles, secs, cps, peps, (long long)chk);
+
+  cudaFree(d_w); cudaFree(d_ain); cudaFree(d_out);
+  return 0;
+}

--- a/bench/systolic/systolic_gpu_grid.cu
+++ b/bench/systolic/systolic_gpu_grid.cu
@@ -1,0 +1,141 @@
+// GPU grid-sync simulation of the weight-stationary systolic array.
+//
+// Extends systolic_gpu.cu past the single-block (N<=32) limit: one array now
+// spans MANY blocks, so the N*N PEs are distributed across all the GPU's SMs
+// and a grid-wide barrier (cooperative groups grid.sync()) replaces
+// __syncthreads() between the read and latch phases each cycle.
+//
+// This is the configuration that actually exercises the whole GPU — the
+// single-block PoC used only one SM.  State lives in GLOBAL memory (a grid
+// spans SMs, so shared memory can't hold shared state); the two grid.sync()
+// per cycle order the read phase before the latch phase across all blocks.
+//
+//   nvcc -O3 -std=c++17 -arch=sm_89 -rdc=true -o systolic_gpu_grid systolic_gpu_grid.cu
+//   ./systolic_gpu_grid <N> <cycles>
+//
+// -rdc=true (relocatable device code) is required for cooperative-groups grid
+// sync.  cudaLaunchCooperativeKernel is used instead of <<<>>> so the driver
+// guarantees all blocks are co-resident (a prerequisite for grid.sync()).
+
+#include "systolic_common.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cuda_runtime.h>
+#include <cooperative_groups.h>
+namespace cg = cooperative_groups;
+
+// a/p are global arrays of length N*N, double-buffered (cur, nxt) so the read
+// phase never sees a half-updated array.  Each thread owns one PE; the grid is
+// sized so that gridDim.x*blockDim.x >= N*N.
+__global__ void systolic_grid_kernel(
+    const int8_t* __restrict__ w,
+    const int32_t* __restrict__ ain,
+    int32_t* __restrict__ a0, int32_t* __restrict__ p0,
+    int32_t* __restrict__ a1, int32_t* __restrict__ p1,
+    int32_t* __restrict__ p_out_final,
+    int N, long cycles)
+{
+  cg::grid_group grid = cg::this_grid();
+  int tid = blockIdx.x * blockDim.x + threadIdx.x;
+  int total = N * N;
+  int i = (tid < total) ? tid / N : 0;
+  int j = (tid < total) ? tid % N : 0;
+
+  if (tid < total) { a0[tid] = 0; p0[tid] = 0; }
+  grid.sync();
+
+  int32_t* a_cur = a0; int32_t* p_cur = p0;
+  int32_t* a_nxt = a1; int32_t* p_nxt = p1;
+
+  for (long c = 0; c < cycles; ++c) {
+    if (tid < total) {
+      int32_t a_in = (j == 0) ? ain[i] : a_cur[i * N + (j - 1)];
+      int32_t p_in = (i == 0) ? 0      : p_cur[(i - 1) * N + j];
+      a_nxt[tid] = a_in;                              // a_out = a_in
+      p_nxt[tid] = p_in + a_in * (int32_t)w[tid];
+    }
+    grid.sync();                                       // all reads done
+    // swap cur/nxt (every thread computes the same pointers — no write race)
+    int32_t* ta = a_cur; a_cur = a_nxt; a_nxt = ta;
+    int32_t* tp = p_cur; p_cur = p_nxt; p_nxt = tp;
+    grid.sync();                                       // latch visible to all
+  }
+
+  if (tid < total && i == N - 1) p_out_final[j] = p_cur[tid];
+}
+
+int main(int argc, char** argv) {
+  int  N      = (argc > 1) ? atoi(argv[1]) : 64;
+  long cycles = (argc > 2) ? atol(argv[2]) : 100000;
+  int  total  = N * N;
+
+  SystolicState s;
+  systolic_init(s, N);
+
+  int8_t*  d_w;   cudaMalloc((void**)&d_w,   total * sizeof(int8_t));
+  int32_t* d_ain; cudaMalloc((void**)&d_ain, N * sizeof(int32_t));
+  int32_t* d_out; cudaMalloc((void**)&d_out, N * sizeof(int32_t));
+  int32_t *d_a0, *d_p0, *d_a1, *d_p1;
+  cudaMalloc((void**)&d_a0, total * sizeof(int32_t));
+  cudaMalloc((void**)&d_p0, total * sizeof(int32_t));
+  cudaMalloc((void**)&d_a1, total * sizeof(int32_t));
+  cudaMalloc((void**)&d_p1, total * sizeof(int32_t));
+  cudaMemcpy(d_w,   s.w.data(),   total * sizeof(int8_t),  cudaMemcpyHostToDevice);
+  cudaMemcpy(d_ain, s.ain.data(), N * sizeof(int32_t),     cudaMemcpyHostToDevice);
+
+  // Grid sizing: cooperative launch requires all blocks co-resident.  Pick a
+  // block size, compute the grid to cover N*N, then verify it fits the device
+  // (max co-resident blocks = SMs * blocks/SM for this kernel).
+  int blockSize = 256;
+  int gridSize  = (total + blockSize - 1) / blockSize;
+
+  int dev; cudaGetDevice(&dev);
+  int numBlocksPerSm = 0;
+  cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+      &numBlocksPerSm, systolic_grid_kernel, blockSize, 0);
+  cudaDeviceProp prop; cudaGetDeviceProperties(&prop, dev);
+  int maxCoresident = numBlocksPerSm * prop.multiProcessorCount;
+  if (gridSize > maxCoresident) {
+    printf("GPU-grid N=%-3d  SKIP (needs %d co-resident blocks, device fits %d "
+           "[%d/SM x %d SMs])\n",
+           N, gridSize, maxCoresident, numBlocksPerSm, prop.multiProcessorCount);
+    return 0;
+  }
+
+  long one = 1;
+  void* argsW[] = { &d_w, &d_ain, &d_a0, &d_p0, &d_a1, &d_p1, &d_out, &N, &one };
+  cudaLaunchCooperativeKernel((void*)systolic_grid_kernel,
+                              gridSize, blockSize, argsW, 0, 0);
+  cudaDeviceSynchronize();  // warm-up
+
+  cudaEvent_t e0, e1; cudaEventCreate(&e0); cudaEventCreate(&e1);
+  void* args[] = { &d_w, &d_ain, &d_a0, &d_p0, &d_a1, &d_p1, &d_out, &N, &cycles };
+  cudaEventRecord(e0);
+  cudaError_t le = cudaLaunchCooperativeKernel((void*)systolic_grid_kernel,
+                              gridSize, blockSize, args, 0, 0);
+  cudaEventRecord(e1);
+  cudaEventSynchronize(e1);
+  cudaError_t se = cudaDeviceSynchronize();
+  if (le != cudaSuccess || se != cudaSuccess) {
+    printf("GPU-grid N=%-3d  launch=%s sync=%s\n", N,
+           cudaGetErrorString(le), cudaGetErrorString(se));
+    return 1;
+  }
+  float ms = 0; cudaEventElapsedTime(&ms, e0, e1);
+
+  std::vector<int32_t> out(N);
+  cudaMemcpy(out.data(), d_out, N * sizeof(int32_t), cudaMemcpyDeviceToHost);
+  int64_t chk = 0;
+  for (int j = 0; j < N; ++j) chk = chk * 1000003 + out[j];
+
+  double secs = ms / 1e3;
+  double cps  = cycles / secs;
+  double peps = cps * (double)total;
+  printf("GPU-grid N=%-3d cycles=%-9ld  %.3f s  %.3e cyc/s  %.3e PE-upd/s  "
+         "checksum=%lld  [grid=%d blk=%d]\n",
+         N, cycles, secs, cps, peps, (long long)chk, gridSize, blockSize);
+
+  cudaFree(d_w); cudaFree(d_ain); cudaFree(d_out);
+  cudaFree(d_a0); cudaFree(d_p0); cudaFree(d_a1); cudaFree(d_p1);
+  return 0;
+}


### PR DESCRIPTION
A measurement PoC (under `bench/systolic/`, not part of the Lean build) answering: **can a GPU speed up the SIM of a *single large* accelerator** — a TPU-like systolic array + RISC-V bank, ~1000+ PEs — as opposed to the batch/Monte-Carlo throughput that PR #115 provides?

The batch backend (#115) runs N independent instances in parallel; you can match its throughput by adding machines, and one instance is slower than the CPU. This PoC targets the opposite axis: **1 PE = 1 thread**, a barrier between the read and latch phases of each clock cycle (#33's "Strategy 4") — making a *single* instance faster, which adding machines cannot do.

## DUT & method
Weight-stationary int8 MAC systolic array, N×N PEs, two-phase (read-then-latch) cycle. `systolic_common.h` is the golden model shared by CPU and GPU, so the PoC compares **schedulers of the same circuit**, not different circuits. Every GPU checksum matched the serial CPU at every N.

Two GPU schedulers:
- **1-block** (`systolic_gpu.cu`): whole array in one block, `__syncthreads()`. Cheap barrier, N≤32.
- **grid-sync** (`systolic_gpu_grid.cu`): array across many blocks/SMs, cooperative-groups `grid.sync()`, double-buffered global state. Any N, uses the whole GPU.

## Results — RTX 4070 Ti (sm_89), driver 565.77 / CUDA 12.7, cycles=200000

| N | PEs | CPU PE/s | 1-block PE/s | grid PE/s | CPU cyc/s | grid cyc/s |
|---|----:|---:|---:|---:|---:|---:|
| 16 | 256 | 1.49e9 | **2.85e9** | 2.30e8 | 5.8e6 | 9.0e5 |
| 32 | 1024 | 2.11e9 | **5.44e9** | 9.18e8 | 2.1e6 | 9.0e5 |
| 64 | 4096 | 1.85e9 | — | 3.64e9 | 4.5e5 | 8.9e5 |
| 128 | 16384 | 1.67e9 | — | 1.45e10 | 1.0e5 | 8.9e5 |
| 256 | 65536 | 8.9e8 | — | **4.34e10** | 1.4e4 | 6.6e5 |

Three regimes: **CPU** PE/s flat, cyc/s collapses as N² (N=256 unusable); **1-block** highest cyc/s (2.6× CPU at N=32, best for one fast run); **grid-sync** PE/s scales linearly with PE count (**49× CPU at N=256**, best for throughput). At N=256 the wall-clock gap is 45× (CPU 7.3 s vs GPU 0.16 s for 100k cycles).

**Answer: yes — and the bigger the design, the more decisively GPU wins.** A ~1000-PE accelerator sits around N=32.

## Scope / caveats
- `bench/` only — no Lean build changes, not wired into CI. Needs `nvcc` + a GPU to run; `run.sh` handles the NixOS driver `LD_LIBRARY_PATH` and the nvcc-version-≤-driver constraint.
- The grid `cyc/s` ceiling (~9e5) is set by two `grid.sync()` per cycle — a barrier-coarsening lever for later, not needed to justify the direction.

## Next step (separate PR)
Emit these kernels from Sparkle IR: port the deferred `CudaDesignStateStruct` hierarchical path (#33) onto CSim so wire-copy between module boundaries is generated, choosing 1-block vs grid-sync by array size. Best done on top of #115.
